### PR TITLE
Use Repositories and Unit of Work patterns

### DIFF
--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -39,7 +39,14 @@ namespace ShapeDungeon.Controllers
                 return RedirectToAction("Create");
             }
 
-            await _playerService.CreatePlayerAsync(player);
+            var isCreated = await _playerService.CreatePlayerAsync(player);
+
+            if (!isCreated)
+            {
+                TempData["duplicate"] = "Player with this name already exists! Try again.";
+                return View(player);
+            }
+
             return RedirectToAction("Active", "Home");
         }
     }

--- a/DTOs/Room/RoomNavDto.cs
+++ b/DTOs/Room/RoomNavDto.cs
@@ -2,8 +2,8 @@
 {
     public class RoomNavDto
     {
-        public int CoordX { get; init; }
-        public int CoordY { get; init; }
+        public int CoordX { get; set; }
+        public int CoordY { get; set; }
         public bool CanGoLeft { get; set; }
         public bool CanGoRight { get; set; }
         public bool CanGoUp { get; set; }

--- a/Data/IUnitOfWork.cs
+++ b/Data/IUnitOfWork.cs
@@ -1,0 +1,7 @@
+﻿namespace ShapeDungeon.Data
+{
+    public interface IUnitOfWork
+    {
+        Task Commit(Action action);
+    }
+}

--- a/Data/UnitOfWork.cs
+++ b/Data/UnitOfWork.cs
@@ -1,0 +1,29 @@
+﻿using ShapeDungeon.Interfaces.Repositories;
+
+namespace ShapeDungeon.Data
+{
+    internal class UnitOfWork : IUnitOfWork
+    {
+        private readonly IDbContext _context;
+
+        public UnitOfWork(IDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task Commit(Action action)
+        {
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                action();
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+    }
+}

--- a/Helpers/AppServiceCollectionExtension.cs
+++ b/Helpers/AppServiceCollectionExtension.cs
@@ -2,6 +2,7 @@
 using ShapeDungeon.Interfaces.Repositories;
 using ShapeDungeon.Interfaces.Services.Players;
 using ShapeDungeon.Interfaces.Services.Rooms;
+using ShapeDungeon.Repos;
 using ShapeDungeon.Services.Players;
 using ShapeDungeon.Services.Rooms;
 
@@ -24,6 +25,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IRoomTravelService, RoomTravelService>();
             services.AddScoped<IRoomActiveForEditService, RoomActiveForEditService>();
             services.AddScoped<ICheckRoomNeighborsService, CheckRoomNeighborsService>();
+
+            // Repos
+            services.AddScoped<IRoomRepository, RoomRepository>();
 
             return services;
         }

--- a/Helpers/AppServiceCollectionExtension.cs
+++ b/Helpers/AppServiceCollectionExtension.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Repos
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IRoomRepository, RoomRepository>();
+            services.AddScoped<IPlayerRepository, PlayerRepository>();
 
             return services;
         }

--- a/Helpers/AppServiceCollectionExtension.cs
+++ b/Helpers/AppServiceCollectionExtension.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<ICheckRoomNeighborsService, CheckRoomNeighborsService>();
 
             // Repos
+            services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IRoomRepository, RoomRepository>();
 
             return services;

--- a/Interfaces/Entity/IPlayer.cs
+++ b/Interfaces/Entity/IPlayer.cs
@@ -4,6 +4,7 @@ namespace ShapeDungeon.Interfaces.Entity
 {
     public interface IPlayer : ICharacter
     {
+        bool IsActive { get; }
         int CurrentExp { get; }
         int ExpToNextLevel { get; }
         int CurrentSkillpoints { get; }

--- a/Interfaces/Entity/IPlayer.cs
+++ b/Interfaces/Entity/IPlayer.cs
@@ -7,6 +7,7 @@ namespace ShapeDungeon.Interfaces.Entity
         int CurrentExp { get; }
         int ExpToNextLevel { get; }
         int CurrentSkillpoints { get; }
+        int CurrentScoutEnergy { get; set; }
         PlayerShape Shape { get; }
     }
 }

--- a/Interfaces/Entity/IRoom.cs
+++ b/Interfaces/Entity/IRoom.cs
@@ -6,7 +6,7 @@ namespace ShapeDungeon.Interfaces.Entity
     {
         bool IsActiveForMove { get; }
         bool IsActiveForScout { get; }
-        bool IsActiveForEdit { get; }
+        bool IsActiveForEdit { get; set; }
         bool CanGoLeft { get; }
         bool CanGoRight { get; }
         bool CanGoUp { get; }

--- a/Interfaces/Entity/IRoom.cs
+++ b/Interfaces/Entity/IRoom.cs
@@ -4,8 +4,8 @@ namespace ShapeDungeon.Interfaces.Entity
 {
     public interface IRoom : IGuidEntity
     {
-        bool IsActiveForMove { get; }
-        bool IsActiveForScout { get; }
+        bool IsActiveForMove { get; set; }
+        bool IsActiveForScout { get; set; }
         bool IsActiveForEdit { get; set; }
         bool CanGoLeft { get; }
         bool CanGoRight { get; }

--- a/Interfaces/Repositories/IDbContext.cs
+++ b/Interfaces/Repositories/IDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using ShapeDungeon.Entities;
 
 namespace ShapeDungeon.Interfaces.Repositories
@@ -12,5 +13,6 @@ namespace ShapeDungeon.Interfaces.Repositories
 
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
         void Dispose();
+        DatabaseFacade Database { get;  }
     }
 }

--- a/Interfaces/Services/Players/IPlayerService.cs
+++ b/Interfaces/Services/Players/IPlayerService.cs
@@ -7,7 +7,5 @@ namespace ShapeDungeon.Interfaces.Services.Players
         Task<bool> CreatePlayerAsync(PlayerDto pDto);
         Task<IEnumerable<PlayerDto>> GetAllPlayersAsync();
         Task<PlayerDto?> GetPlayerAsync(string name);
-
-        void Dispose();
     }
 }

--- a/Interfaces/Services/Rooms/IGetRoomService.cs
+++ b/Interfaces/Services/Rooms/IGetRoomService.cs
@@ -4,8 +4,8 @@ namespace ShapeDungeon.Interfaces.Services.Rooms
 {
     public interface IGetRoomService
     {
-        Task<RoomDto?> GetActiveForMoveAsync();
-        Task<RoomDto?> GetActiveForScoutAsync();
-        Task<RoomDetailsDto?> GetActiveForEditAsync();
+        Task<RoomDto> GetActiveForMoveAsync();
+        Task<RoomDto> GetActiveForScoutAsync();
+        Task<RoomDetailsDto> GetActiveForEditAsync();
     }
 }

--- a/Repos/IPlayerRepository.cs
+++ b/Repos/IPlayerRepository.cs
@@ -1,0 +1,21 @@
+﻿using ShapeDungeon.Interfaces.Entity;
+
+namespace ShapeDungeon.Repos
+{
+    public interface IPlayerRepository
+    {
+        /// <summary>
+        /// Players need scout energy in order to scout adjacent rooms.
+        /// Only one can be active. There can be no active players.
+        /// </summary>
+        /// <returns>The scout energy of the currently IsActive == true player. If no active player, null.</returns>
+        Task<int?> GetActiveScoutEnergy();
+
+        /// <summary>
+        /// Only one player can be active.
+        /// There can be no active players.
+        /// </summary>
+        /// <returns>The active player or null.</returns>
+        Task<IPlayer?> GetActive();
+    }
+}

--- a/Repos/IPlayerRepository.cs
+++ b/Repos/IPlayerRepository.cs
@@ -17,5 +17,26 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <returns>The active player or null.</returns>
         Task<IPlayer?> GetActive();
+
+        /// <summary>
+        /// All players have names.
+        /// </summary>
+        /// <returns>Player if one exists with given name, otherwise null.</returns>
+        Task<IPlayer?> GetByName(string name);
+
+        /// <summary>
+        /// Many players can be present and selected.
+        /// </summary>
+        /// <returns>List of all created players.</returns>
+        Task<IEnumerable<IPlayer>> GetAll();
+
+        /// <summary>
+        /// Used to check if a player name is present in the database.
+        /// </summary>
+        /// <param name="name">Name that is being checked.</param>
+        /// <returns>True if name is in the database, otherwise false.</returns>
+        Task<bool> DoesNameExist(string name);
+
+        Task AddAsync(IPlayer player);
     }
 }

--- a/Repos/IRoomRepository.cs
+++ b/Repos/IRoomRepository.cs
@@ -1,0 +1,28 @@
+﻿using ShapeDungeon.Interfaces.Entity;
+
+namespace ShapeDungeon.Repos
+{
+    public interface IRoomRepository
+    {
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room in which the player currently is and can move from.</returns>
+        Task<IRoom> GetActiveForMove();
+
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room in which the player currently is or is scouting from.</returns>
+        Task<IRoom> GetActiveForScout();
+
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room that is currently active in edit mode.</returns>
+        Task<IRoom> GetActiveForEdit();
+    }
+}

--- a/Repos/IRoomRepository.cs
+++ b/Repos/IRoomRepository.cs
@@ -42,7 +42,21 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <returns>The room that is currently active in edit mode.</returns>
         Task<IRoom> GetActiveForEdit();
+
+        /// <summary>
+        /// Rooms are placed on a coordinate system done with integers.
+        /// </summary>
+        /// <returns>Coord X of the room that has IsActiveForEdit == true.</returns>
+        Task<int> GetActiveForEditCoordX();
+
+        /// <summary>
+        /// Rooms are placed on a coordinate system done with integers.
+        /// </summary>
+        /// <returns>Coord Y of the room that has IsActiveForEdit == true.</returns>
+        Task<int> GetActiveForEditCoordY();
         #endregion
+
+        void AddAsync(IRoom room);
 
         void Update(IRoom room);
     }

--- a/Repos/IRoomRepository.cs
+++ b/Repos/IRoomRepository.cs
@@ -7,6 +7,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room in which the player currently is and can move from.</returns>
         Task<IRoom> GetActiveForMove();
@@ -14,6 +15,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room in which the player currently is or is scouting from.</returns>
         Task<IRoom> GetActiveForScout();
@@ -21,6 +23,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room that is currently active in edit mode.</returns>
         Task<IRoom> GetActiveForEdit();

--- a/Repos/IRoomRepository.cs
+++ b/Repos/IRoomRepository.cs
@@ -1,9 +1,24 @@
-﻿using ShapeDungeon.Interfaces.Entity;
+﻿using ShapeDungeon.Entities;
+using ShapeDungeon.Interfaces.Entity;
 
 namespace ShapeDungeon.Repos
 {
     public interface IRoomRepository
     {
+        #region Get methods
+        /// <summary>
+        /// </summary>
+        /// <param name="id">Guid for the room's id.</param>
+        /// <returns>Room with matching id or null.</returns>
+        Task<IRoom?> GetById(Guid id);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="coordX">CoordX of the Room.</param>
+        /// <param name="coordY">CoordY of the ROom.</param>
+        /// <returns>Room with matching coords or null.</returns>
+        Task<IRoom?> GetByCoords(int coordX, int coordY);
+
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
@@ -27,5 +42,8 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <returns>The room that is currently active in edit mode.</returns>
         Task<IRoom> GetActiveForEdit();
+        #endregion
+
+        void Update(IRoom room);
     }
 }

--- a/Repos/IRoomRepository.cs
+++ b/Repos/IRoomRepository.cs
@@ -56,7 +56,7 @@ namespace ShapeDungeon.Repos
         Task<int> GetActiveForEditCoordY();
         #endregion
 
-        void AddAsync(IRoom room);
+        Task AddAsync(IRoom room);
 
         void Update(IRoom room);
     }

--- a/Repos/PlayerRepository.cs
+++ b/Repos/PlayerRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using ShapeDungeon.Entities;
 using ShapeDungeon.Interfaces.Entity;
 using ShapeDungeon.Interfaces.Repositories;
 
@@ -27,7 +28,34 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <returns>The active player or null.</returns>
         public async Task<IPlayer?> GetActive()
-            => await this.Context.Players
-                .SingleOrDefaultAsync(x => x.IsActive);
+            => await this.Context.Players.SingleOrDefaultAsync(x => x.IsActive);
+
+        /// <summary>
+        /// All players have names.
+        /// </summary>
+        /// <returns>Player if one exists with given name, otherwise null.</returns>
+        public async Task<IPlayer?> GetByName(string name)
+            => await this.Context.Players.FirstOrDefaultAsync(x => x.Name == name);
+
+        /// <summary>
+        /// Many players can be present and selected.
+        /// </summary>
+        /// <returns>List of all created players.</returns>
+        public async Task<IEnumerable<IPlayer>> GetAll()
+            => await this.Context.Players.ToListAsync();
+
+        /// <summary>
+        /// Used to check if a player name is present in the database.
+        /// </summary>
+        /// <param name="name">Name that is being checked.</param>
+        /// <returns>True if name is in the database, otherwise false.</returns>
+        public async Task<bool> DoesNameExist(string name)
+            => await this.Context.Players.AnyAsync(x => x.Name == name);
+
+        public async Task AddAsync(IPlayer player)
+        {
+            var playerToAdd = (Player)player;
+            await this.Context.Players.AddAsync(playerToAdd);
+        }
     }
 }

--- a/Repos/PlayerRepository.cs
+++ b/Repos/PlayerRepository.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShapeDungeon.Interfaces.Entity;
+using ShapeDungeon.Interfaces.Repositories;
+
+namespace ShapeDungeon.Repos
+{
+    public class PlayerRepository : RepositoryBase<IPlayer>, IPlayerRepository
+    {
+        public PlayerRepository(IDbContext context) : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Players need scout energy in order to scout adjacent rooms.
+        /// Only one can be active. There can be no active players.
+        /// </summary>
+        /// <returns>The scout energy of the currently IsActive == true player. If no active player, null.</returns>
+        public async Task<int?> GetActiveScoutEnergy()
+            => await this.Context.Players
+                .Where(x => x.IsActive)
+                .Select(x => x.CurrentScoutEnergy)
+                .SingleOrDefaultAsync();
+
+        /// <summary>
+        /// Only one player can be active.
+        /// There can be no active players.
+        /// </summary>
+        /// <returns>The active player or null.</returns>
+        public async Task<IPlayer?> GetActive()
+            => await this.Context.Players
+                .SingleOrDefaultAsync(x => x.IsActive);
+    }
+}

--- a/Repos/RepositoryBase.cs
+++ b/Repos/RepositoryBase.cs
@@ -1,0 +1,15 @@
+﻿using ShapeDungeon.Interfaces.Repositories;
+
+namespace ShapeDungeon.Repos
+{
+    public abstract class RepositoryBase<T>
+        where T : class
+    {
+        internal RepositoryBase(IDbContext context)
+        {
+            Context = context;
+        }
+
+        protected IDbContext Context { get; }
+    }
+}

--- a/Repos/RoomRepository.cs
+++ b/Repos/RoomRepository.cs
@@ -77,7 +77,7 @@ namespace ShapeDungeon.Repos
                 .SingleOrDefaultAsync();
         #endregion
 
-        public async void AddAsync(IRoom room)
+        public async Task AddAsync(IRoom room)
         {
             var roomToAdd = (Room)room;
             await this.Context.Rooms.AddAsync(roomToAdd);

--- a/Repos/RoomRepository.cs
+++ b/Repos/RoomRepository.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShapeDungeon.Interfaces.Entity;
+using ShapeDungeon.Interfaces.Repositories;
+
+namespace ShapeDungeon.Repos
+{
+    public class RoomRepository : RepositoryBase<IRoom>, IRoomRepository
+    {
+        public RoomRepository(IDbContext context) : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room in which the player currently is and can move from.</returns>
+        public async Task<IRoom> GetActiveForMove()
+            => await this.Context.Rooms.SingleAsync(x => x.IsActiveForMove);
+
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room in which the player currently is or is scouting from.</returns>
+        public async Task<IRoom> GetActiveForScout()
+            => await this.Context.Rooms.SingleAsync(x => x.IsActiveForScout);
+
+        /// <summary>
+        /// Not possible for the room to be null.
+        /// Start room will always exist, and it'll have this property set to true.
+        /// </summary>
+        /// <returns>The room that is currently active in edit mode.</returns>
+        public async Task<IRoom> GetActiveForEdit()
+            => await this.Context.Rooms.SingleAsync(x => x.IsActiveForEdit);
+    }
+}

--- a/Repos/RoomRepository.cs
+++ b/Repos/RoomRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using ShapeDungeon.Entities;
 using ShapeDungeon.Interfaces.Entity;
 using ShapeDungeon.Interfaces.Repositories;
 
@@ -9,6 +10,22 @@ namespace ShapeDungeon.Repos
         public RoomRepository(IDbContext context) : base(context)
         {
         }
+
+        #region Get methods
+        /// <summary>
+        /// </summary>
+        /// <param name="id">Guid for the room's id.</param>
+        /// <returns>Room with matching id.</returns>
+        public async Task<IRoom?> GetById(Guid id)
+            => await this.Context.Rooms.FirstOrDefaultAsync(x => x.Id == id);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="coordX">CoordX of the Room.</param>
+        /// <param name="coordY">CoordY of the ROom.</param>
+        /// <returns>Room with matching coords or null.</returns>
+        public async Task<IRoom?> GetByCoords(int coordX, int coordY) 
+            => await this.Context.Rooms.SingleOrDefaultAsync(x => x.CoordX == coordX && x.CoordY == coordY);
 
         /// <summary>
         /// Not possible for the room to be null.
@@ -36,5 +53,12 @@ namespace ShapeDungeon.Repos
         /// <returns>The room that is currently active in edit mode.</returns>
         public async Task<IRoom> GetActiveForEdit()
             => await this.Context.Rooms.SingleAsync(x => x.IsActiveForEdit);
+        #endregion
+
+        public void Update(IRoom room)
+        {
+            var updatedRoom = (Room)room;
+            this.Context.Rooms.Update(updatedRoom);
+        }
     }
 }

--- a/Repos/RoomRepository.cs
+++ b/Repos/RoomRepository.cs
@@ -13,6 +13,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room in which the player currently is and can move from.</returns>
         public async Task<IRoom> GetActiveForMove()
@@ -21,6 +22,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room in which the player currently is or is scouting from.</returns>
         public async Task<IRoom> GetActiveForScout()
@@ -29,6 +31,7 @@ namespace ShapeDungeon.Repos
         /// <summary>
         /// Not possible for the room to be null.
         /// Start room will always exist, and it'll have this property set to true.
+        /// SingleAsync used since only one room can have this property set to true at a time.
         /// </summary>
         /// <returns>The room that is currently active in edit mode.</returns>
         public async Task<IRoom> GetActiveForEdit()

--- a/Repos/RoomRepository.cs
+++ b/Repos/RoomRepository.cs
@@ -53,7 +53,35 @@ namespace ShapeDungeon.Repos
         /// <returns>The room that is currently active in edit mode.</returns>
         public async Task<IRoom> GetActiveForEdit()
             => await this.Context.Rooms.SingleAsync(x => x.IsActiveForEdit);
+
+        /// <summary>
+        /// Rooms are placed on a coordinate system done with integers.
+        /// Only one room can have the property IsActiveForEdit set to true.
+        /// </summary>
+        /// <returns>Coord X of the room that has IsActiveForEdit == true.</returns>
+        public async Task<int> GetActiveForEditCoordX()
+            => await this.Context.Rooms
+                .Where(x => x.IsActiveForEdit)
+                .Select(x => x.CoordX)
+                .SingleOrDefaultAsync();
+
+        /// <summary>
+        /// Rooms are placed on a coordinate system done with integers.
+        /// Only one room can have the property IsActiveForEdit set to true.
+        /// </summary>
+        /// <returns>Coord Y of the room that has IsActiveForEdit == true.</returns>
+        public async Task<int> GetActiveForEditCoordY()
+            => await this.Context.Rooms
+                .Where(x => x.IsActiveForEdit)
+                .Select(x => x.CoordY)
+                .SingleOrDefaultAsync();
         #endregion
+
+        public async void AddAsync(IRoom room)
+        {
+            var roomToAdd = (Room)room;
+            await this.Context.Rooms.AddAsync(roomToAdd);
+        }
 
         public void Update(IRoom room)
         {

--- a/Services/Rooms/CheckRoomNeighborsService.cs
+++ b/Services/Rooms/CheckRoomNeighborsService.cs
@@ -1,5 +1,4 @@
 ﻿using ShapeDungeon.DTOs.Room;
-using ShapeDungeon.Interfaces.Repositories;
 using ShapeDungeon.Interfaces.Services.Rooms;
 using ShapeDungeon.Repos;
 
@@ -9,7 +8,7 @@ namespace ShapeDungeon.Services.Rooms
     {
         private readonly IRoomRepository _roomRepository;
 
-        public CheckRoomNeighborsService(IDbContext context, IRoomRepository roomRepository)
+        public CheckRoomNeighborsService(IRoomRepository roomRepository)
         {
             _roomRepository = roomRepository;
         }

--- a/Services/Rooms/CheckRoomNeighborsService.cs
+++ b/Services/Rooms/CheckRoomNeighborsService.cs
@@ -1,17 +1,17 @@
-﻿using Microsoft.EntityFrameworkCore;
-using ShapeDungeon.DTOs.Room;
+﻿using ShapeDungeon.DTOs.Room;
 using ShapeDungeon.Interfaces.Repositories;
 using ShapeDungeon.Interfaces.Services.Rooms;
+using ShapeDungeon.Repos;
 
 namespace ShapeDungeon.Services.Rooms
 {
     public class CheckRoomNeighborsService : ICheckRoomNeighborsService
     {
-        private readonly IDbContext _context;
+        private readonly IRoomRepository _roomRepository;
 
-        public CheckRoomNeighborsService(IDbContext context)
+        public CheckRoomNeighborsService(IDbContext context, IRoomRepository roomRepository)
         {
-            _context = context;
+            _roomRepository = roomRepository;
         }
 
         public async Task<RoomNavDto?> SetDtoNeighborsAsync(int coordX, int coordY)
@@ -47,37 +47,28 @@ namespace ShapeDungeon.Services.Rooms
 
         private async Task<RoomNavDto?> InitializeCheckRoomAsync(int coordX, int coordY)
         {
-            var room = await _context.Rooms
-                .Where(x => x.CoordX == coordX && x.CoordY == coordY)
-                .Select(x => new RoomNavDto()
-                {
-                    CoordX = x.CoordX,
-                    CoordY = x.CoordY,
-                    CanGoLeft = x.CanGoLeft,
-                    CanGoRight = x.CanGoRight,
-                    CanGoUp = x.CanGoUp,
-                    CanGoDown = x.CanGoDown,
-                    HasLeftNeighbor = false,
-                    HasRightNeighbor = false,
-                    HasUpNeighbor = false,
-                    HasDownNeighbor = false,
-                })
-                .SingleOrDefaultAsync();
+            var room = await _roomRepository.GetByCoords(coordX, coordY);
+            var roomDto = new RoomNavDto();
+            if (room != null)
+            {
+                roomDto.CoordX = room.CoordX;
+                roomDto.CoordY = room.CoordY;
+                roomDto.CanGoLeft = room.CanGoLeft;
+                roomDto.CanGoRight = room.CanGoRight;
+                roomDto.CanGoUp = room.CanGoUp;
+                roomDto.CanGoDown = room.CanGoDown;
+                roomDto.HasLeftNeighbor = false;
+                roomDto.HasRightNeighbor = false;
+                roomDto.HasUpNeighbor = false;
+                roomDto.HasDownNeighbor = false;
+            }
 
-            return room;
+            return roomDto;
         }
 
         private async Task<bool> IsRoomWithCoordsValidAsync(int coordX, int coordY)
         {
-            var room = await _context.Rooms
-                .Where(x => x.CoordX == coordX && x.CoordY == coordY)
-                .Select(x => new RoomCoordsDto()
-                {
-                    CoordX = x.CoordX,
-                    CoordY = x.CoordY,
-                })
-                .SingleOrDefaultAsync();
-
+            var room = await _roomRepository.GetByCoords(coordX, coordY);
             return room != null;
         }
     }

--- a/Services/Rooms/GetRoomService.cs
+++ b/Services/Rooms/GetRoomService.cs
@@ -1,77 +1,82 @@
-﻿using Microsoft.EntityFrameworkCore;
-using ShapeDungeon.DTOs.Room;
-using ShapeDungeon.Interfaces.Repositories;
+﻿using ShapeDungeon.DTOs.Room;
 using ShapeDungeon.Interfaces.Services.Rooms;
+using ShapeDungeon.Repos;
 
 namespace ShapeDungeon.Services.Rooms
 {
     public class GetRoomService : IGetRoomService
     {
-        private readonly IDbContext _context;
+        private readonly IRoomRepository _roomRepository;
 
-        public GetRoomService(IDbContext context)
+        public GetRoomService(IRoomRepository roomRepository)
         {
-            _context = context;
+            _roomRepository = roomRepository;
         }
 
-        public async Task<RoomDto?> GetActiveForMoveAsync()
-            => await _context.Rooms
-                .Where(x => x.IsActiveForMove)
-                .Select(x => new RoomDto()
-                {
-                    IsActiveForMove = x.IsActiveForMove,
-                    IsActiveForScout = x.IsActiveForScout,
-                    CanGoLeft = x.CanGoLeft,
-                    CanGoRight = x.CanGoRight,
-                    CanGoUp = x.CanGoUp,
-                    CanGoDown = x.CanGoDown,
-                    IsStartRoom = x.IsStartRoom,
-                    IsSafeRoom = x.IsSafeRoom,
-                    IsEnemyRoom = x.IsEnemyRoom,
-                    IsEndRoom = x.IsEndRoom,
-                    CoordX = x.CoordX,
-                    CoordY = x.CoordY,
-                })
-                .SingleOrDefaultAsync();
+        public async Task<RoomDto> GetActiveForMoveAsync()
+        {
+            var room = await _roomRepository.GetActiveForMove();
+            var roomDto = new RoomDto()
+            {
+                IsActiveForMove = room.IsActiveForMove,
+                IsActiveForScout = room.IsActiveForScout,
+                CanGoLeft = room.CanGoLeft,
+                CanGoRight = room.CanGoRight,
+                CanGoUp = room.CanGoUp,
+                CanGoDown = room.CanGoDown,
+                IsStartRoom = room.IsStartRoom,
+                IsSafeRoom = room.IsSafeRoom,
+                IsEnemyRoom = room.IsEnemyRoom,
+                IsEndRoom = room.IsEndRoom,
+                CoordX = room.CoordX,
+                CoordY = room.CoordY,
+            };
 
-        public async Task<RoomDto?> GetActiveForScoutAsync()
-            => await _context.Rooms
-                .Where(x => x.IsActiveForScout)
-                .Select(x => new RoomDto()
-                {
-                    IsActiveForMove = x.IsActiveForMove,
-                    IsActiveForScout = x.IsActiveForScout,
-                    CanGoLeft = x.CanGoLeft,
-                    CanGoRight = x.CanGoRight,
-                    CanGoUp = x.CanGoUp,
-                    CanGoDown = x.CanGoDown,
-                    IsStartRoom = x.IsStartRoom,
-                    IsSafeRoom = x.IsSafeRoom,
-                    IsEnemyRoom = x.IsEnemyRoom,
-                    IsEndRoom = x.IsEndRoom,
-                    CoordX = x.CoordX,
-                    CoordY = x.CoordY,
-                })
-                .SingleOrDefaultAsync();
+            return roomDto;
+        }
 
-        public async Task<RoomDetailsDto?> GetActiveForEditAsync()
-            => await _context.Rooms
-                .Where(x => x.IsActiveForEdit)
-                .Select(x => new RoomDetailsDto()
-                {
-                    IsActiveForEdit = x.IsActiveForEdit,
-                    CanGoLeft = x.CanGoLeft,
-                    CanGoRight = x.CanGoRight,
-                    CanGoUp = x.CanGoUp,
-                    CanGoDown = x.CanGoDown,
-                    IsStartRoom = x.IsStartRoom,
-                    IsSafeRoom = x.IsSafeRoom,
-                    IsEnemyRoom = x.IsEnemyRoom,
-                    IsEndRoom = x.IsEndRoom,
-                    Enemy = null,
-                    CoordX = x.CoordX,
-                    CoordY = x.CoordY,
-                })
-                .SingleOrDefaultAsync();
+        public async Task<RoomDto> GetActiveForScoutAsync()
+        {
+            var room = await _roomRepository.GetActiveForScout();
+            var roomDto = new RoomDto()
+            {
+                IsActiveForMove = room.IsActiveForMove,
+                IsActiveForScout = room.IsActiveForScout,
+                CanGoLeft = room.CanGoLeft,
+                CanGoRight = room.CanGoRight,
+                CanGoUp = room.CanGoUp,
+                CanGoDown = room.CanGoDown,
+                IsStartRoom = room.IsStartRoom,
+                IsSafeRoom = room.IsSafeRoom,
+                IsEnemyRoom = room.IsEnemyRoom,
+                IsEndRoom = room.IsEndRoom,
+                CoordX = room.CoordX,
+                CoordY = room.CoordY,
+            };
+
+            return roomDto;
+        }
+
+        public async Task<RoomDetailsDto> GetActiveForEditAsync()
+        {
+            var room = await _roomRepository.GetActiveForEdit();
+            var roomDto = new RoomDetailsDto()
+            {
+                IsActiveForEdit = room.IsActiveForEdit,
+                CanGoLeft = room.CanGoLeft,
+                CanGoRight = room.CanGoRight,
+                CanGoUp = room.CanGoUp,
+                CanGoDown = room.CanGoDown,
+                IsStartRoom = room.IsStartRoom,
+                IsSafeRoom = room.IsSafeRoom,
+                IsEnemyRoom = room.IsEnemyRoom,
+                IsEndRoom = room.IsEndRoom,
+                Enemy = null,
+                CoordX = room.CoordX,
+                CoordY = room.CoordY,
+            };
+
+            return roomDto;
+        }
     }
 }

--- a/Services/Rooms/RoomCreateService.cs
+++ b/Services/Rooms/RoomCreateService.cs
@@ -54,6 +54,7 @@ namespace ShapeDungeon.Services.Rooms
             return room.Id;
         }
 
+        // There's always going to be an IsActiveForEditRoom == true.
         public async Task<RoomDetailsDto> InitializeRoomAsync(RoomDirection roomDirection)
         {
             var roomDto = new RoomDetailsDto();

--- a/Views/Player/Create.cshtml
+++ b/Views/Player/Create.cshtml
@@ -75,3 +75,9 @@
         toastr.error("Player name can't be empty.");
     </script>
 }
+else if (@TempData["duplicate"] != null) 
+{
+    <script>
+        toastr.error("Player with this name already exists! Try again.");
+    </script>
+}


### PR DESCRIPTION
Had to rework the services. They used the app context for everything beforehand.

Now they are using repositories for getting entities from the database, and the unit of work pattern for saving changes to the database.

Also noticed that there was no error message for the case when a user creates a player with an already existing name.