### PR TITLE
Add Initial Enemy Functionality

### DIFF
--- a/Controllers/EnemyController.cs
+++ b/Controllers/EnemyController.cs
@@ -16,7 +16,7 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public IActionResult Create()
         {
-            var model = new EnemyDto();
+            var model = new EnemyDto() { Level = 5};
             return View(model);
         }
 

--- a/Controllers/EnemyController.cs
+++ b/Controllers/EnemyController.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ShapeDungeon.DTOs;
+using ShapeDungeon.Interfaces.Services.Enemies;
+
+namespace ShapeDungeon.Controllers
+{
+    public class EnemyController : Controller
+    {
+        private readonly IEnemyService _enemyService;
+
+        public EnemyController(IEnemyService enemyService)
+        {
+            _enemyService = enemyService;
+        }
+
+        [HttpGet]
+        public IActionResult Create()
+        {
+            var model = new EnemyDto();
+            return View(model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create(EnemyDto enemy)
+        {
+            if (!ModelState.IsValid)
+            {
+                TempData["error"] = "Name can't be empty";
+                return RedirectToAction("Create");
+            }
+
+            await _enemyService.CreateAsync(enemy);
+            return RedirectToAction("Active", "Home");
+        }
+    }
+}

--- a/Controllers/EnemyController.cs
+++ b/Controllers/EnemyController.cs
@@ -16,7 +16,8 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public IActionResult Create()
         {
-            var model = new EnemyDto() { Level = 5};
+            // Level = 8 because the selected on page load square shape stats add up to this number.
+            var model = new EnemyDto() { Level = 8 };
             return View(model);
         }
 

--- a/DTOs/EnemyDto.cs
+++ b/DTOs/EnemyDto.cs
@@ -1,4 +1,6 @@
-﻿namespace ShapeDungeon.DTOs
+﻿using ShapeDungeon.Entities.Enums;
+
+namespace ShapeDungeon.DTOs
 {
     public class EnemyDto
     {
@@ -10,5 +12,6 @@
         public int Agility { get; set; }
         public int Level { get; set; }
         public int DroppedExp { get; set; }
+        public Shape Shape { get; set; }
     }
 }

--- a/DTOs/Players/PlayerDto.cs
+++ b/DTOs/Players/PlayerDto.cs
@@ -18,7 +18,7 @@ namespace ShapeDungeon.DTOs.Players
         public int CurrentSkillpoints { get; set; }
         public int CurrentScoutEnergy { get; set; }
 
-        public PlayerShape Shape { get; set; }
+        public Shape Shape { get; set; }
 
         public static implicit operator PlayerDto(Player player)
             => new()

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -12,9 +12,16 @@ namespace ShapeDungeon.Data
         public AppDbContext(DbContextOptions<AppDbContext> options)
             : base(options) { }
 
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            builder.Entity<EnemyRoom>()
+                .HasKey(x => new { x.EnemyId, x.RoomId });
+        }
+
         public DbSet<Enemy> Enemies { get; set; }
         public DbSet<Item> Items { get; set; }
         public DbSet<Player> Players { get; set; }
         public DbSet<Room> Rooms { get; set; }
+        public DbSet<EnemyRoom> EnemiesRooms { get; set; }
     }
 }

--- a/Entities/Enemy.cs
+++ b/Entities/Enemy.cs
@@ -1,4 +1,5 @@
-﻿using ShapeDungeon.Interfaces.Entity;
+﻿using ShapeDungeon.Entities.Enums;
+using ShapeDungeon.Interfaces.Entity;
 
 namespace ShapeDungeon.Entities
 {
@@ -20,5 +21,7 @@ namespace ShapeDungeon.Entities
         public int DroppedExp { get; set; }
 
         public int CurrentHp { get; set; }
+
+        public Shape Shape { get; set; }
     }
 }

--- a/Entities/Enemy.cs
+++ b/Entities/Enemy.cs
@@ -1,5 +1,4 @@
 ﻿using ShapeDungeon.Interfaces.Entity;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShapeDungeon.Entities
 {
@@ -19,5 +18,7 @@ namespace ShapeDungeon.Entities
         public int Level { get; set; }
 
         public int DroppedExp { get; set; }
+
+        public int CurrentHp { get; set; }
     }
 }

--- a/Entities/EnemyRoom.cs
+++ b/Entities/EnemyRoom.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ShapeDungeon.Entities
+{
+    public class EnemyRoom
+    {
+        [ForeignKey(nameof(Enemy))]
+        public Guid EnemyId { get; set; }
+
+        public Enemy Enemy { get; set; }
+            = null!;
+
+        [ForeignKey(nameof(Room))]
+        public Guid RoomId { get; set; }
+
+        public Room Room { get; set; }
+            = null!;
+    }
+}

--- a/Entities/EnemyRoom.cs
+++ b/Entities/EnemyRoom.cs
@@ -15,5 +15,7 @@ namespace ShapeDungeon.Entities
 
         public Room Room { get; set; }
             = null!;
+
+        public bool IsEnemyDefeated { get; set; }
     }
 }

--- a/Entities/Enums/Shape.cs
+++ b/Entities/Enums/Shape.cs
@@ -1,6 +1,6 @@
 ﻿namespace ShapeDungeon.Entities.Enums
 {
-    public enum PlayerShape
+    public enum Shape
     {
         Square = 0,
         Triangle = 1,

--- a/Entities/Player.cs
+++ b/Entities/Player.cs
@@ -28,6 +28,6 @@ namespace ShapeDungeon.Entities
 
         public int CurrentScoutEnergy { get; set; }
 
-        public PlayerShape Shape { get; set; }
+        public Shape Shape { get; set; }
     }
 }

--- a/Helpers/AppServiceCollectionExtension.cs
+++ b/Helpers/AppServiceCollectionExtension.cs
@@ -1,8 +1,10 @@
 ﻿using ShapeDungeon.Data;
 using ShapeDungeon.Interfaces.Repositories;
+using ShapeDungeon.Interfaces.Services.Enemies;
 using ShapeDungeon.Interfaces.Services.Players;
 using ShapeDungeon.Interfaces.Services.Rooms;
 using ShapeDungeon.Repos;
+using ShapeDungeon.Services.Enemies;
 using ShapeDungeon.Services.Players;
 using ShapeDungeon.Services.Rooms;
 
@@ -19,6 +21,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IPlayerService, PlayerService>();
             services.AddScoped<IPlayerScoutService, PlayerScoutService>();
 
+            // Enemy
+            services.AddScoped<IEnemyService, EnemyService>();
+
             // Room
             services.AddScoped<IGetRoomService, GetRoomService>();
             services.AddScoped<IRoomCreateService, RoomCreateService>();
@@ -29,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Repos
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IRoomRepository, RoomRepository>();
+            services.AddScoped<IEnemyRepository, EnemyRepository>();
             services.AddScoped<IPlayerRepository, PlayerRepository>();
 
             return services;

--- a/Interfaces/Entity/IEnemy.cs
+++ b/Interfaces/Entity/IEnemy.cs
@@ -3,5 +3,6 @@
     public interface IEnemy : ICharacter
     {
         int DroppedExp { get; }
+        int CurrentHp { get; }
     }
 }

--- a/Interfaces/Entity/IPlayer.cs
+++ b/Interfaces/Entity/IPlayer.cs
@@ -9,6 +9,6 @@ namespace ShapeDungeon.Interfaces.Entity
         int ExpToNextLevel { get; }
         int CurrentSkillpoints { get; }
         int CurrentScoutEnergy { get; set; }
-        PlayerShape Shape { get; }
+        Shape Shape { get; }
     }
 }

--- a/Interfaces/Services/Enemies/IEnemyService.cs
+++ b/Interfaces/Services/Enemies/IEnemyService.cs
@@ -1,0 +1,9 @@
+﻿using ShapeDungeon.DTOs;
+
+namespace ShapeDungeon.Interfaces.Services.Enemies
+{
+    public interface IEnemyService
+    {
+        Task CreateAsync(EnemyDto eDto);
+    }
+}

--- a/Migrations/20230608110626_UpdateEnemyEntity.Designer.cs
+++ b/Migrations/20230608110626_UpdateEnemyEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -11,9 +12,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230608110626_UpdateEnemyEntity")]
+    partial class UpdateEnemyEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20230608110626_UpdateEnemyEntity.cs
+++ b/Migrations/20230608110626_UpdateEnemyEntity.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class UpdateEnemyEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CurrentHp",
+                table: "Enemies",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CurrentHp",
+                table: "Enemies");
+        }
+    }
+}

--- a/Migrations/20230608111337_AddEnemiesRoomsEntity.Designer.cs
+++ b/Migrations/20230608111337_AddEnemiesRoomsEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -11,9 +12,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230608111337_AddEnemiesRoomsEntity")]
+    partial class AddEnemiesRoomsEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20230608111337_AddEnemiesRoomsEntity.cs
+++ b/Migrations/20230608111337_AddEnemiesRoomsEntity.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class AddEnemiesRoomsEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EnemiesRooms",
+                columns: table => new
+                {
+                    EnemyId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoomId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EnemiesRooms", x => new { x.EnemyId, x.RoomId });
+                    table.ForeignKey(
+                        name: "FK_EnemiesRooms_Enemies_EnemyId",
+                        column: x => x.EnemyId,
+                        principalTable: "Enemies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EnemiesRooms_Rooms_RoomId",
+                        column: x => x.RoomId,
+                        principalTable: "Rooms",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EnemiesRooms_RoomId",
+                table: "EnemiesRooms",
+                column: "RoomId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EnemiesRooms");
+        }
+    }
+}

--- a/Migrations/20230608113703_AddEnemyShape.Designer.cs
+++ b/Migrations/20230608113703_AddEnemyShape.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -11,9 +12,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230608113703_AddEnemyShape")]
+    partial class AddEnemyShape
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20230608113703_AddEnemyShape.cs
+++ b/Migrations/20230608113703_AddEnemyShape.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class AddEnemyShape : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Shape",
+                table: "Enemies",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Shape",
+                table: "Enemies");
+        }
+    }
+}

--- a/Migrations/20230608132734_AddIsEnemyDefeatedToEnemiesRoomsEntity.Designer.cs
+++ b/Migrations/20230608132734_AddIsEnemyDefeatedToEnemiesRoomsEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -11,9 +12,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230608132734_AddIsEnemyDefeatedToEnemiesRoomsEntity")]
+    partial class AddIsEnemyDefeatedToEnemiesRoomsEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20230608132734_AddIsEnemyDefeatedToEnemiesRoomsEntity.cs
+++ b/Migrations/20230608132734_AddIsEnemyDefeatedToEnemiesRoomsEntity.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class AddIsEnemyDefeatedToEnemiesRoomsEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsEnemyDefeated",
+                table: "EnemiesRooms",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsEnemyDefeated",
+                table: "EnemiesRooms");
+        }
+    }
+}

--- a/Repos/EnemyRepository.cs
+++ b/Repos/EnemyRepository.cs
@@ -1,0 +1,15 @@
+﻿using ShapeDungeon.Entities;
+using ShapeDungeon.Interfaces.Repositories;
+
+namespace ShapeDungeon.Repos
+{
+    public class EnemyRepository : RepositoryBase<Enemy>, IEnemyRepository
+    {
+        public EnemyRepository(IDbContext context) : base(context)
+        {
+        }
+
+        public async Task AddAsync(Enemy enemy)
+            => await this.Context.Enemies.AddAsync(enemy);
+    }
+}

--- a/Repos/IEnemyRepository.cs
+++ b/Repos/IEnemyRepository.cs
@@ -1,0 +1,9 @@
+﻿using ShapeDungeon.Entities;
+
+namespace ShapeDungeon.Repos
+{
+    public interface IEnemyRepository
+    {
+        Task AddAsync(Enemy enemy);
+    }
+}

--- a/Services/Enemies/EnemyService.cs
+++ b/Services/Enemies/EnemyService.cs
@@ -1,0 +1,42 @@
+﻿using ShapeDungeon.Data;
+using ShapeDungeon.DTOs;
+using ShapeDungeon.Entities;
+using ShapeDungeon.Interfaces.Services.Enemies;
+using ShapeDungeon.Repos;
+
+namespace ShapeDungeon.Services.Enemies
+{
+    public class EnemyService : IEnemyService
+    {
+        private readonly IEnemyRepository _enemyRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public EnemyService(
+            IEnemyRepository enemyRepository, 
+            IUnitOfWork unitOfWork)
+        {
+            _enemyRepository = enemyRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task CreateAsync(EnemyDto eDto)
+        {
+            var enemy = new Enemy()
+            {
+                Name = $"{eDto.Name} Lvl.{eDto.Level}",
+                Strength = eDto.Strength,
+                Vigor = eDto.Vigor,
+                Agility = eDto.Agility,
+                Level = eDto.Level,
+                DroppedExp = eDto.Level * 10,
+                CurrentHp = eDto.Vigor + eDto.Strength,
+                Shape = eDto.Shape,
+            };
+
+            await _unitOfWork.Commit(() =>
+            {
+                _enemyRepository.AddAsync(enemy);
+            });
+        }
+    }
+}

--- a/Views/Enemy/Create.cshtml
+++ b/Views/Enemy/Create.cshtml
@@ -1,0 +1,86 @@
+﻿@using ShapeDungeon.DTOs
+@model EnemyDto
+
+@{
+    ViewBag.Title = "Create Enemy";
+}
+
+<div class="container" style="width:100vw;height:75vh">
+    <div class="row text-center mt-4" style="height:10%">
+        <h2>@ViewBag.Title</h2>
+    </div>
+    <div class="row align-items-center" style="height:80%">
+        <form method="post" class="col-sm-6">
+            <div class="btn-group" role="group" aria-label="Choose Shape:" style="width:100%">
+              <input type="radio" class="btn-check" name="shape" id="square" asp-for="@Model.Shape" value="Square" checked>
+              <label class="btn btn-outline-danger" for="square">Square</label>
+              <input type="radio" class="btn-check" name="shape" id="triangle" asp-for="@Model.Shape" value="Triangle">
+              <label class="btn btn-outline-danger" for="triangle">Triangle</label>
+              <input type="radio" class="btn-check" name="shape" id="circle" asp-for="@Model.Shape" value="Circle">
+              <label class="btn btn-outline-danger" for="circle">Circle</label>
+            </div>
+
+            <hr class="border-3 border-top border-danger">
+
+            <div class="form-group row">
+                <label for="enemy-name" class="col-sm-3 col-form-label">Enemy Name:</label>
+                <div class="col-9">
+                    <input type="text" class="form-control" asp-for="@Model.Name" placeholder="Squary" />
+                </div>
+            </div>
+
+            <hr class="border-3 border-top border-danger">
+
+            <div class="form-group row">
+                <label for="enemy-level" class="col-sm-3 col-form-label">Enemy Level:</label>
+                <div class="col-9">
+                    <input type="text" class="form-control" asp-for="@Model.Level" placeholder="5" />
+                </div>
+            </div>
+
+            <hr class="border-3 border-top border-danger">
+
+            <div class="form-group row">
+                <label for="strength" class="col-sm-3 col-form-label">Strength:</label>
+                <div class="col-sm-1">
+                    <input type="text" class="form-control-plaintext" id="strength" asp-for="@Model.Strength" value="2">
+                </div>
+
+                <label for="vigor" class="col-sm-3 col-form-label">Vigor:</label>
+                <div class="col-sm-1">
+                    <input type="text" class="form-control-plaintext" id="vigor" asp-for="@Model.Vigor" value="5">
+                </div>
+
+                <label for="agility" class="col-sm-3 col-form-label">Agility:</label>
+                <div class="col-sm-1">
+                    <input type="text" class="form-control-plaintext" id="agility" asp-for="@Model.Agility" value="1">
+                </div>
+            </div>
+
+            <hr class="border-3 border-top border-danger">
+
+            <div class="form-group row mx-auto" style="width:90%">
+                <button class="btn btn-outline-danger text-center" type="submit">Create</button>
+            </div>
+        </form>
+
+
+        <div class="col-sm-5 position-relative">
+            <div
+                id="selected-shape"
+                style="height:10rem;width:10rem;background-color:#cc0000"
+                class="position-absolute top-50 start-50 translate-middle"
+            >
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src=~/js/enemy/create.js></script>
+
+@if (@TempData["error"] != null)
+{
+    <script>
+        toastr.error("Enemy name and stats can't be empty.");
+    </script>
+}

--- a/Views/Enemy/Create.cshtml
+++ b/Views/Enemy/Create.cshtml
@@ -31,11 +31,12 @@
 
             <hr class="border-3 border-top border-danger">
 
-            <div class="form-group row">
+            <div class="form-group row align-items-center">
                 <label for="enemy-level" class="col-sm-3 col-form-label">Enemy Level:</label>
-                <div class="col-9">
+                <div class="col-2">
                     <input type="text" class="form-control" asp-for="@Model.Level" placeholder="5" />
                 </div>
+                <span class="col-7" style="font-size:0.85rem;color:gray;font-style:italic">(Enemy level is appended to the name, e.g. Squary Lvl.5)</span>
             </div>
 
             <hr class="border-3 border-top border-danger">

--- a/Views/Enemy/Create.cshtml
+++ b/Views/Enemy/Create.cshtml
@@ -34,7 +34,7 @@
             <div class="form-group row align-items-center">
                 <label for="enemy-level" class="col-sm-3 col-form-label">Enemy Level:</label>
                 <div class="col-2">
-                    <input type="text" class="form-control" asp-for="@Model.Level" placeholder="5" />
+                    <input type="text" class="form-control-plaintext" readonly id="level" asp-for="@Model.Level" placeholder="5" />
                 </div>
                 <span class="col-7" style="font-size:0.85rem;color:gray;font-style:italic">(Enemy level is appended to the name, e.g. Squary Lvl.5)</span>
             </div>

--- a/Views/Enemy/Create.cshtml
+++ b/Views/Enemy/Create.cshtml
@@ -68,7 +68,7 @@
         <div class="col-sm-5 position-relative">
             <div
                 id="selected-shape"
-                style="height:10rem;width:10rem;background-color:#cc0000"
+                style="height:10rem;width:10rem;background-color:red"
                 class="position-absolute top-50 start-50 translate-middle"
             >
             </div>

--- a/Views/Home/_Player.cshtml
+++ b/Views/Home/_Player.cshtml
@@ -4,21 +4,21 @@
 @model PlayerDto
 
 <td class="align-middle position-relative" style="width:50vw">
-    @if (Model.Shape == PlayerShape.Square)
+    @if (Model.Shape == Shape.Square)
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"
          style="height:7.5rem;width:7.5rem;background-color:limegreen">
         </div>
     }
-    else if (Model.Shape == PlayerShape.Triangle)
+    else if (Model.Shape == Shape.Triangle)
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"
          style="width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid limegreen;border-bottom: 5rem solid transparent">
         </div>
     }
-    else if (Model.Shape == PlayerShape.Circle)
+    else if (Model.Shape == Shape.Circle)
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"

--- a/Views/Home/_PlayerOutline.cshtml
+++ b/Views/Home/_PlayerOutline.cshtml
@@ -4,14 +4,14 @@
 @model PlayerDto
 
 <td class="align-middle position-relative" style="width:50vw">
-    @if (Model.Shape == PlayerShape.Square)
+    @if (Model.Shape == Shape.Square)
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"
          style="height:7.5rem;width:7.5rem;border:0.25rem solid limegreen">
         </div>
     }
-    else if (Model.Shape == PlayerShape.Triangle)
+    else if (Model.Shape == Shape.Triangle)
     {
         <div 
             id="player"
@@ -25,7 +25,7 @@
             </div>
         </div>
     }
-    else if (Model.Shape == PlayerShape.Circle)
+    else if (Model.Shape == Shape.Circle)
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"

--- a/Views/Room/_CreationForm.cshtml
+++ b/Views/Room/_CreationForm.cshtml
@@ -36,11 +36,47 @@
     <input type="hidden" name="CoordX" asp-for="@Model.CoordX" value="@Model.CoordX" />
     <input type="hidden" name="CoordY" asp-for="@Model.CoordY" value="@Model.CoordY" />
 
-    Insert extra stuff here homie
+    <div id="enemy-form" style="display:none">
+        <p class="text-center mb-1">Which enemy is in the room?</p>
+        <p class="text-center mb-1" style="font-size:0.85rem;color:gray">Enemy level range:</p>
 
-    <hr class="border-3 border-top border-success">
+        <div class="form-group row text-center d-flex justify-content-center align-items-center mb-3" style="font-size:0.90rem">
+            <label for="min-level" class="col-sm-1 col-form-label" style="font-size:0.85rem">Min:</label>
+            <div class="col-sm-1">
+                <input type="text" class="form-control-plaintext plaintext-input" id="min-level" value="0">
+            </div>
+
+            <label for="max-level" class="col-sm-1 col-form-label" style="font-size:0.85rem">Max:</label>
+            <div class="col-sm-1">
+                <input type="text" class="form-control-plaintext plaintext-input" id="max-level" value="100">
+            </div>
+
+            <div class="col-sm-3">
+                <a class="btn btn-outline-warning text-center" style="font-size:0.65rem" id="update-enemy-range">Update Dropdown</a>
+            </div>
+        </div>
+
+        <select class="form-select" style="width:65%;margin:auto" aria-label="Enemy Select">
+            <option value="0">Enemy</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+        </select>
+
+        <hr class="border-3 border-top border-success">
+    </div>
 
     <div class="form-group row mx-auto" style="width:90%">
         <button class="btn btn-outline-success text-center" id="create-room-btn" type="submit">Create</button>
     </div>
 </form>
+
+<style>
+    .plaintext-input {
+        background: lightgray;
+        color: #cc0000;
+        text-align: center;
+        border-radius: 0.5rem;
+        font-size: 0.75rem;
+    }
+</style>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -35,6 +35,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Room" asp-action="Create">Create Room</a>
                         </li>
+                        <li>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Enemy" asp-action="Create">Create Enemy</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/wwwroot/js/enemy/create.js
+++ b/wwwroot/js/enemy/create.js
@@ -12,15 +12,15 @@ for (const radioBtn of radioBtns) {
     radioBtn.addEventListener("click", () => {
         switch (radioBtn.id) {
             case "square":
-                shape.setAttribute("style", "height:10rem;width:10rem;background-color:#cc0000");
+                shape.setAttribute("style", "height:10rem;width:10rem;background-color:red");
                 setEnemyAttributes("square");
                 break;
             case "triangle":
-                shape.setAttribute("style", "width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid #cc0000;border-bottom: 5rem solid transparent");
+                shape.setAttribute("style", "width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid red;border-bottom: 5rem solid transparent");
                 setEnemyAttributes("triangle");
                 break;
             case "circle":
-                shape.setAttribute("style", "height:10rem;width:10rem;background-color:#cc0000;border-radius:50%");
+                shape.setAttribute("style", "height:10rem;width:10rem;background-color:red;border-radius:50%");
                 setEnemyAttributes("circle");
                 break;
             default:

--- a/wwwroot/js/enemy/create.js
+++ b/wwwroot/js/enemy/create.js
@@ -72,5 +72,4 @@ function updateEnemyLevel() {
     const currAgility = Number(agilityEl.value);
 
     levelEl.value = currStrength + currVigor + currAgility;
-    console.log(levelEl.value);
 }

--- a/wwwroot/js/enemy/create.js
+++ b/wwwroot/js/enemy/create.js
@@ -3,10 +3,15 @@ const shape = document.getElementById("selected-shape");
 const strengthEl = document.getElementById("strength");
 const vigorEl = document.getElementById("vigor");
 const agilityEl = document.getElementById("agility");
+const levelEl = document.getElementById("level");
 
 strengthEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
 vigorEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
 agilityEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
+
+strengthEl.addEventListener("change", updateEnemyLevel);
+vigorEl.addEventListener("change", updateEnemyLevel);
+agilityEl.addEventListener("change", updateEnemyLevel);
 
 for (const radioBtn of radioBtns) {
     radioBtn.addEventListener("click", () => {
@@ -27,6 +32,8 @@ for (const radioBtn of radioBtns) {
                 console.log("bruh, there's an error...");
                 break;
         }
+
+        updateEnemyLevel();
     })
 }
 
@@ -57,4 +64,13 @@ function setEnemyAttributes(shape) {
     strengthEl.value = newStrength;
     vigorEl.value = newVigor;
     agilityEl.value = newAgility;
+}
+
+function updateEnemyLevel() {
+    const currStrength = Number(strengthEl.value);
+    const currVigor = Number(vigorEl.value);
+    const currAgility = Number(agilityEl.value);
+
+    levelEl.value = currStrength + currVigor + currAgility;
+    console.log(levelEl.value);
 }

--- a/wwwroot/js/enemy/create.js
+++ b/wwwroot/js/enemy/create.js
@@ -1,0 +1,60 @@
+﻿const radioBtns = document.getElementsByName("shape");
+const shape = document.getElementById("selected-shape");
+const strengthEl = document.getElementById("strength");
+const vigorEl = document.getElementById("vigor");
+const agilityEl = document.getElementById("agility");
+
+strengthEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
+vigorEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
+agilityEl.setAttribute("style", "background:lightgray;color:#cc0000;text-align:center;border-radius:0.5rem");
+
+for (const radioBtn of radioBtns) {
+    radioBtn.addEventListener("click", () => {
+        switch (radioBtn.id) {
+            case "square":
+                shape.setAttribute("style", "height:10rem;width:10rem;background-color:#cc0000");
+                setEnemyAttributes("square");
+                break;
+            case "triangle":
+                shape.setAttribute("style", "width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid #cc0000;border-bottom: 5rem solid transparent");
+                setEnemyAttributes("triangle");
+                break;
+            case "circle":
+                shape.setAttribute("style", "height:10rem;width:10rem;background-color:#cc0000;border-radius:50%");
+                setEnemyAttributes("circle");
+                break;
+            default:
+                console.log("bruh, there's an error...");
+                break;
+        }
+    })
+}
+
+function setEnemyAttributes(shape) {
+    let newStrength, newVigor, newAgility;
+
+    switch (shape) {
+        case "square":
+            newStrength = 2;
+            newVigor = 5;
+            newAgility = 1;
+            break;
+        case "triangle":
+            newStrength = 5;
+            newVigor = 3;
+            newAgility = 2;
+            break;
+        case "circle":
+            newStrength = 2;
+            newVigor = 2;
+            newAgility = 5;
+            break;
+        default:
+            console.log("bruh, there's an error...");
+            break;
+    }
+
+    strengthEl.value = newStrength;
+    vigorEl.value = newVigor;
+    agilityEl.value = newAgility;
+}

--- a/wwwroot/js/room/create.js
+++ b/wwwroot/js/room/create.js
@@ -15,6 +15,8 @@ const endRadioBtn = document.getElementById("end-room-option");
 const roomEl = document.getElementById("room");
 const roomCreateBtn = document.getElementById("create-room-btn");
 
+const enemyForm = document.getElementById("enemy-form");
+
 const roomDirectionBtnArr = [leftRadioBtn, rightRadioBtn, upRadioBtn, downRadioBtn];
 const roomTypeBtnArr = [startRadioBtn, safeRadioBtn, enemyRadioBtn, endRadioBtn];
 
@@ -69,10 +71,10 @@ function toggleRadioHighlight(direction) {
 function toggleRoomOptionBackground() {
     const currRoomOption = this.id;
     switch (currRoomOption) {
-        case "start-label": roomEl.style.background = "#2a9fd669"; break;
-        case "safe-label": roomEl.style.background = "#77b30069"; break;
-        case "enemy-label": roomEl.style.background = "#cc000069"; break;
-        case "end-label": roomEl.style.background = "#9933cc69"; break;
+        case "start-label": roomEl.style.background = "#2a9fd669"; hideEnemyForm(); break;
+        case "safe-label": roomEl.style.background = "#77b30069"; hideEnemyForm(); break;
+        case "enemy-label": roomEl.style.background = "#cc000069"; displayEnemyForm(); break;
+        case "end-label": roomEl.style.background = "#9933cc69"; hideEnemyForm(); break;
         default: console.log("bruh, room option error..."); break;
     }
 
@@ -132,8 +134,16 @@ function updateRoomOnLoad() {
 
     if (startRadioBtn.checked) roomEl.style.background = "#2a9fd669";
     else if (safeRadioBtn.checked) roomEl.style.background = "#77b30069";
-    else if (enemyRadioBtn.checked) roomEl.style.background = "#cc000069";
     else if (endRadioBtn.checked) roomEl.style.background = "#9933cc69";
+    else if (enemyRadioBtn.checked) roomEl.style.background = "#cc000069";
+}
+
+function displayEnemyForm() {
+    enemyForm.style.display = "block";
+}
+
+function hideEnemyForm() {
+    enemyForm.style.display = "none";
 }
 
 function disableCreationBtns() {


### PR DESCRIPTION
Enemies can now be created. Their level depends on the stats that are entered (_it's a sum of all three of them_). The level gets appended to the name of the enemy automatically (_e.g. Squary is level 10 - Squary Lvl.10_).
The enemy creation page also has a different color than the player creation page (_such front end, much style_).