### PR TITLE
Fix Wall Phasing Bug

### DIFF
--- a/ShapeDungeon/DTOs/Rooms/RoomDto.cs
+++ b/ShapeDungeon/DTOs/Rooms/RoomDto.cs
@@ -24,6 +24,10 @@ namespace ShapeDungeon.DTOs.Rooms
         public bool HasRightNeighbor { get; set; }
         public bool HasUpNeighbor { get; set; }
         public bool HasDownNeighbor { get; set; }
+        public bool IsLeftDeadEnd { get; set; }
+        public bool IsRightDeadEnd { get; set; }
+        public bool IsUpDeadEnd { get; set; }
+        public bool IsDownDeadEnd { get; set; }
 
         public static implicit operator RoomDto(Room room)
             => new()

--- a/ShapeDungeon/DTOs/Rooms/RoomNavDto.cs
+++ b/ShapeDungeon/DTOs/Rooms/RoomNavDto.cs
@@ -14,6 +14,10 @@ namespace ShapeDungeon.DTOs.Rooms
         public bool HasRightNeighbor { get; set; }
         public bool HasUpNeighbor { get; set; }
         public bool HasDownNeighbor { get; set; }
+        public bool IsLeftDeadEnd { get; set; }
+        public bool IsRightDeadEnd { get; set; }
+        public bool IsUpDeadEnd { get; set; }
+        public bool IsDownDeadEnd { get; set; }
 
         public static implicit operator RoomNavDto(Room room)
             => new()

--- a/ShapeDungeon/Repos/IRoomRepository.cs
+++ b/ShapeDungeon/Repos/IRoomRepository.cs
@@ -65,7 +65,7 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <param name="coordX">The X coordinate of the room that is being checked.</param>
         /// <param name="coordY">The Y coordinate of the room that is being checked.</param>
-        /// <param name="direction">The direction from which the player will be entering the checked room.</param>
+        /// <param name="direction">The direction from which the player will be leaving their current room.</param>
         /// <returns>True, if there's no dead end. False, if it's a dead end.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If incorrect direction enum is provided exception is thrown.</exception>
         Task<bool> CanEnterRoomFromDirection(int coordX, int coordY, RoomDirection direction);

--- a/ShapeDungeon/Repos/IRoomRepository.cs
+++ b/ShapeDungeon/Repos/IRoomRepository.cs
@@ -1,4 +1,5 @@
 ﻿using ShapeDungeon.Entities;
+using ShapeDungeon.Helpers.Enums;
 
 namespace ShapeDungeon.Repos
 {
@@ -58,5 +59,15 @@ namespace ShapeDungeon.Repos
         Task AddAsync(Room room);
 
         void Update(Room room);
+
+        /// <summary>
+        /// Checks if the player can enter a room with provided coords from provided direction.
+        /// </summary>
+        /// <param name="coordX">The X coordinate of the room that is being checked.</param>
+        /// <param name="coordY">The Y coordinate of the room that is being checked.</param>
+        /// <param name="direction">The direction from which the player will be entering the checked room.</param>
+        /// <returns>True, if there's no dead end. False, if it's a dead end.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If incorrect direction enum is provided exception is thrown.</exception>
+        Task<bool> CanEnterRoomFromDirection(int coordX, int coordY, RoomDirection direction);
     }
 }

--- a/ShapeDungeon/Repos/RoomRepository.cs
+++ b/ShapeDungeon/Repos/RoomRepository.cs
@@ -88,7 +88,7 @@ namespace ShapeDungeon.Repos
         /// </summary>
         /// <param name="coordX">The X coordinate of the room that is being checked.</param>
         /// <param name="coordY">The Y coordinate of the room that is being checked.</param>
-        /// <param name="direction">The direction from which the player will be entering the checked room.</param>
+        /// <param name="direction">The direction from which the player will be leaving their current room.</param>
         /// <returns>True, if there's no dead end. False, if it's a dead end.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If incorrect direction enum is provided exception is thrown.</exception>
         public async Task<bool> CanEnterRoomFromDirection(int coordX, int coordY, RoomDirection direction)

--- a/ShapeDungeon/Repos/RoomRepository.cs
+++ b/ShapeDungeon/Repos/RoomRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using ShapeDungeon.Entities;
+using ShapeDungeon.Helpers.Enums;
 using ShapeDungeon.Interfaces.Repositories;
 
 namespace ShapeDungeon.Repos
@@ -81,5 +82,33 @@ namespace ShapeDungeon.Repos
 
         public void Update(Room room)
             => this.Context.Rooms.Update(room);
+
+        /// <summary>
+        /// Checks if the player can enter a room with provided coords from provided direction.
+        /// </summary>
+        /// <param name="coordX">The X coordinate of the room that is being checked.</param>
+        /// <param name="coordY">The Y coordinate of the room that is being checked.</param>
+        /// <param name="direction">The direction from which the player will be entering the checked room.</param>
+        /// <returns>True, if there's no dead end. False, if it's a dead end.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If incorrect direction enum is provided exception is thrown.</exception>
+        public async Task<bool> CanEnterRoomFromDirection(int coordX, int coordY, RoomDirection direction)
+        {
+            var room = await this.GetByCoords(coordX, coordY);
+            var canGo = false;
+
+            if (room != null)
+            {
+                canGo = direction switch
+                {
+                    RoomDirection.Left => room.CanGoRight,
+                    RoomDirection.Right => room.CanGoLeft,
+                    RoomDirection.Top => room.CanGoDown,
+                    RoomDirection.Bottom => room.CanGoUp,
+                    _ => throw new ArgumentOutOfRangeException(nameof(direction)),
+                };
+            }
+
+            return canGo;
+        }
     }
 }

--- a/ShapeDungeon/Services/Rooms/CheckRoomNeighborsService.cs
+++ b/ShapeDungeon/Services/Rooms/CheckRoomNeighborsService.cs
@@ -1,4 +1,5 @@
 ﻿using ShapeDungeon.DTOs.Rooms;
+using ShapeDungeon.Helpers.Enums;
 using ShapeDungeon.Interfaces.Services.Rooms;
 using ShapeDungeon.Repos;
 
@@ -20,16 +21,28 @@ namespace ShapeDungeon.Services.Rooms
             if (currRoom != null)
             {
                 if (currRoom.CanGoLeft)
+                {
                     currRoom.HasLeftNeighbor = await IsRoomWithCoordsValidAsync(coordX - 1, coordY);
+                    currRoom.IsLeftDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX - 1, coordY, RoomDirection.Left));
+                }
 
                 if (currRoom.CanGoRight)
+                {
                     currRoom.HasRightNeighbor = await IsRoomWithCoordsValidAsync(coordX + 1, coordY);
+                    currRoom.IsRightDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX + 1, coordY, RoomDirection.Right));
+                }
 
                 if (currRoom.CanGoUp)
+                {
                     currRoom.HasUpNeighbor = await IsRoomWithCoordsValidAsync(coordX, coordY + 1);
+                    currRoom.IsUpDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX, coordY + 1, RoomDirection.Top));
+                }
 
                 if (currRoom.CanGoDown)
+                {
                     currRoom.HasDownNeighbor = await IsRoomWithCoordsValidAsync(coordX, coordY - 1);
+                    currRoom.IsDownDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX, coordY - 1, RoomDirection.Bottom));
+                }
             }
 
             return currRoom;
@@ -41,6 +54,10 @@ namespace ShapeDungeon.Services.Rooms
             room.HasRightNeighbor = roomNav.HasRightNeighbor;
             room.HasUpNeighbor = roomNav.HasUpNeighbor;
             room.HasDownNeighbor = roomNav.HasDownNeighbor;
+            room.IsLeftDeadEnd = roomNav.IsLeftDeadEnd;
+            room.IsRightDeadEnd = roomNav.IsRightDeadEnd;
+            room.IsUpDeadEnd = roomNav.IsUpDeadEnd;
+            room.IsDownDeadEnd = roomNav.IsDownDeadEnd;
             return room;
         }
 
@@ -64,6 +81,26 @@ namespace ShapeDungeon.Services.Rooms
         {
             var room = await _roomRepository.GetByCoords(coordX, coordY);
             return room != null;
+        }
+
+        private async Task<bool> CanEnterRoomWithCoordsFromDirection(int coordX, int coordY, RoomDirection direction)
+        {
+            var room = await _roomRepository.GetByCoords(coordX, coordY);
+            var canGo = false;
+
+            if (room != null)
+            {
+                switch (direction)
+                {
+                    case RoomDirection.Left: canGo = room.CanGoRight; break;
+                    case RoomDirection.Right: canGo = room.CanGoLeft;  break;
+                    case RoomDirection.Top: canGo = room.CanGoDown;  break;
+                    case RoomDirection.Bottom: canGo = room.CanGoUp; break;
+                    default: throw new ArgumentOutOfRangeException(nameof(direction));
+                }
+            }
+
+            return canGo;
         }
     }
 }

--- a/ShapeDungeon/Services/Rooms/CheckRoomNeighborsService.cs
+++ b/ShapeDungeon/Services/Rooms/CheckRoomNeighborsService.cs
@@ -23,25 +23,29 @@ namespace ShapeDungeon.Services.Rooms
                 if (currRoom.CanGoLeft)
                 {
                     currRoom.HasLeftNeighbor = await IsRoomWithCoordsValidAsync(coordX - 1, coordY);
-                    currRoom.IsLeftDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX - 1, coordY, RoomDirection.Left));
+                    currRoom.IsLeftDeadEnd = !(await _roomRepository
+                        .CanEnterRoomFromDirection(coordX - 1, coordY, RoomDirection.Left));
                 }
 
                 if (currRoom.CanGoRight)
                 {
                     currRoom.HasRightNeighbor = await IsRoomWithCoordsValidAsync(coordX + 1, coordY);
-                    currRoom.IsRightDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX + 1, coordY, RoomDirection.Right));
+                    currRoom.IsRightDeadEnd = !(await _roomRepository
+                        .CanEnterRoomFromDirection(coordX + 1, coordY, RoomDirection.Right));
                 }
 
                 if (currRoom.CanGoUp)
                 {
                     currRoom.HasUpNeighbor = await IsRoomWithCoordsValidAsync(coordX, coordY + 1);
-                    currRoom.IsUpDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX, coordY + 1, RoomDirection.Top));
+                    currRoom.IsUpDeadEnd = !(await _roomRepository
+                        .CanEnterRoomFromDirection(coordX, coordY + 1, RoomDirection.Top));
                 }
 
                 if (currRoom.CanGoDown)
                 {
                     currRoom.HasDownNeighbor = await IsRoomWithCoordsValidAsync(coordX, coordY - 1);
-                    currRoom.IsDownDeadEnd = !(await CanEnterRoomWithCoordsFromDirection(coordX, coordY - 1, RoomDirection.Bottom));
+                    currRoom.IsDownDeadEnd = !(await _roomRepository
+                        .CanEnterRoomFromDirection(coordX, coordY - 1, RoomDirection.Bottom));
                 }
             }
 
@@ -81,26 +85,6 @@ namespace ShapeDungeon.Services.Rooms
         {
             var room = await _roomRepository.GetByCoords(coordX, coordY);
             return room != null;
-        }
-
-        private async Task<bool> CanEnterRoomWithCoordsFromDirection(int coordX, int coordY, RoomDirection direction)
-        {
-            var room = await _roomRepository.GetByCoords(coordX, coordY);
-            var canGo = false;
-
-            if (room != null)
-            {
-                switch (direction)
-                {
-                    case RoomDirection.Left: canGo = room.CanGoRight; break;
-                    case RoomDirection.Right: canGo = room.CanGoLeft;  break;
-                    case RoomDirection.Top: canGo = room.CanGoDown;  break;
-                    case RoomDirection.Bottom: canGo = room.CanGoUp; break;
-                    default: throw new ArgumentOutOfRangeException(nameof(direction));
-                }
-            }
-
-            return canGo;
         }
     }
 }

--- a/ShapeDungeon/Services/Rooms/RoomTravelService.cs
+++ b/ShapeDungeon/Services/Rooms/RoomTravelService.cs
@@ -36,20 +36,20 @@ namespace ShapeDungeon.Services.Rooms
             switch (direction)
             {
                 case RoomDirection.Left: 
-                    if (oldRoom.CanGoLeft)
-                        coordX--;  
+                    var isLeftDeadEnd = !(await _roomRepository.CanEnterRoomFromDirection(coordX - 1, coordY, RoomDirection.Left));
+                    if (oldRoom.CanGoLeft && !isLeftDeadEnd) coordX--;
                     break;
-                case RoomDirection.Right: 
-                    if (oldRoom.CanGoRight)
-                        coordX++;  
+                case RoomDirection.Right:
+                    var isRightDeadEnd = !(await _roomRepository.CanEnterRoomFromDirection(coordX + 1, coordY, RoomDirection.Right));
+                    if (oldRoom.CanGoRight && !isRightDeadEnd) coordX++;  
                     break;
                 case RoomDirection.Top: 
-                    if (oldRoom.CanGoUp)
-                        coordY++; 
+                    var isUpDeadEnd = !(await _roomRepository.CanEnterRoomFromDirection(coordX, coordY + 1, RoomDirection.Top));
+                    if (oldRoom.CanGoUp && !isUpDeadEnd) coordY++; 
                     break;
                 case RoomDirection.Bottom: 
-                    if (oldRoom.CanGoDown)
-                        coordY--;  
+                    var isDownDeadEnd = !(await _roomRepository.CanEnterRoomFromDirection(coordX, coordY - 1, RoomDirection.Bottom));
+                    if (oldRoom.CanGoDown && !isDownDeadEnd) coordY--;  
                     break;
                 default: throw new ArgumentOutOfRangeException(nameof(direction));
             }

--- a/ShapeDungeon/Views/Home/_RoomWithNav.cshtml
+++ b/ShapeDungeon/Views/Home/_RoomWithNav.cshtml
@@ -12,7 +12,19 @@
         <div id="move-up"
              class="position-absolute"
              style="width:100%;">
-            @if (Model.HasUpNeighbor)
+            @if (Model.CanGoUp && !Model.HasUpNeighbor)
+            {
+                <a class="btn btn-outline-danger disabled fixed-dir-btn up-dir-btn void">
+                    Void!
+                </a>
+            }
+            else if (Model.IsUpDeadEnd)
+            {
+                <a class="btn btn-outline-warning disabled fixed-dir-btn up-dir-btn void">
+                    Dead End!
+                </a>
+            }
+            else if (Model.HasUpNeighbor)
             {
                 @if (Model.IsActiveForMove)
                 {
@@ -39,16 +51,24 @@
                 }
                 
             }
-            else if (Model.CanGoUp)
-            {
-                <button type="button" class="btn btn-outline-danger fixed-dir-btn up-dir-btn void" disabled>Void!</button>
-            }
         </div>
 
         <div id="move-down"
              class="position-absolute"
              style="width:100%;height:100%;">
-            @if (Model.HasDownNeighbor)
+            @if (Model.CanGoDown && !Model.HasDownNeighbor)
+            {
+                <a class="btn btn-outline-danger disabled fixed-dir-btn down-dir-btn void">
+                    Void!
+                </a>
+            }
+            else if (Model.IsDownDeadEnd)
+            {
+                <a class="btn btn-outline-warning disabled fixed-dir-btn down-dir-btn void">
+                    Dead End!
+                </a>
+            }
+            else if (Model.HasDownNeighbor)
             {
                 @if (Model.IsActiveForMove)
                 {
@@ -74,16 +94,24 @@
                     </a> 
                 }
             }
-            else if (Model.CanGoDown)
-            {
-                <button type="button" class="btn btn-outline-danger fixed-dir-btn down-dir-btn void" disabled>Void!</button>
-            }
         </div>
 
         <div id="move-left"
              class="position-absolute"
              style="width:100%;height:100%;">
-            @if (Model.HasLeftNeighbor)
+            @if (Model.CanGoLeft && !Model.HasLeftNeighbor)
+            {
+                <a class="btn btn-outline-danger disabled fixed-dir-btn left-dir-btn void">
+                    Void!
+                </a>
+            }
+            else if (Model.IsLeftDeadEnd)
+            {
+                <a class="btn btn-outline-warning disabled fixed-dir-btn left-dir-btn void">
+                    Dead End!
+                </a>
+            }
+            else if (Model.HasLeftNeighbor)
             {
                 @if (Model.IsActiveForMove)
                 {
@@ -109,16 +137,22 @@
                     </a> 
                 }
             }
-            else if (Model.CanGoLeft)
-            {
-                <button type="button" class="btn btn-outline-danger fixed-dir-btn left-dir-btn void" disabled>Void!</button>
-            }
         </div>
 
         <div id="move-right"
              class="position-absolute"
              style="width:100%;height:100%;">
-            @if (Model.HasRightNeighbor)
+            @if (Model.CanGoRight && !Model.HasRightNeighbor)
+            {
+                <button type="button" class="btn btn-outline-danger fixed-dir-btn right-dir-btn void" disabled>Void!</button>
+            }
+            else if (Model.IsRightDeadEnd)
+            {
+                <a class="btn btn-outline-warning disabled fixed-dir-btn right-dir-btn void">
+                    Dead End!
+                </a>
+            }
+            else if (Model.HasRightNeighbor)
             {
                 @if (Model.IsActiveForMove)
                 {
@@ -143,10 +177,6 @@
                         Scout
                     </a> 
                 }
-            }
-            else if (Model.CanGoRight)
-            {
-                <button type="button" class="btn btn-outline-danger fixed-dir-btn right-dir-btn void" disabled>Void!</button>
             }
         </div>
 

--- a/ShapeDungeon/wwwroot/css/buttons-active.css
+++ b/ShapeDungeon/wwwroot/css/buttons-active.css
@@ -51,7 +51,7 @@
 }
 
 .left-dir-btn.void {
-    transform: translate(0%, -315%);
+    transform: translate(8%, -315%);
 }
 
 .right-dir-btn {
@@ -69,5 +69,5 @@
 }
 
 .right-dir-btn.void {
-    transform: translate(0%, -315%);
+    transform: translate(-8%, -315%);
 }

--- a/ShapeDungeon/wwwroot/css/buttons-scouting.css
+++ b/ShapeDungeon/wwwroot/css/buttons-scouting.css
@@ -23,7 +23,7 @@
 }
 
 .left-dir-btn.void, .left-dir-btn.scout {
-    transform: translate(0%, -315%);
+    transform: translate(8%, -315%);
 }
 
 .right-dir-btn {
@@ -33,5 +33,5 @@
 }
 
 .right-dir-btn.void, .right-dir-btn.scout {
-    transform: translate(0%, -315%);
+    transform: translate(-8%, -315%);
 }


### PR DESCRIPTION
## Wall Phasing Bug
- E.g. 2 rooms, 1st with coords 0, 0 & 2nd with 1, 0.
- 1st room has a wall on its left side, meaning you can't go in that direction.
- 2nd room doesn't have a wall on its right side, meaning you can go in that direction.
- 2nd room's right side leads to 1st room's left side (_a side with a wall_).
- Instead of having a movement/scout option on the right side of the 2nd room, the player sees "Dead End!", and can't proceed in that direction.
- Changing the URL manually doesn't allow the player to go in a "Dead End!" direction.