### PR TITLE
Bug - Creating Rooms with Existing Coords

### DIFF
--- a/ShapeDungeon/Controllers/RoomController.cs
+++ b/ShapeDungeon/Controllers/RoomController.cs
@@ -77,6 +77,12 @@ namespace ShapeDungeon.Controllers
         public async Task<IActionResult> Directional(RoomDirection direction)
         {
             var roomDetails = await _roomCreateService.InitializeRoomAsync(direction);
+            if (await _roomCreateService.AreCoordsInUse(roomDetails.CoordX, roomDetails.CoordY))
+            {
+                TempData["error"] = "bruh, there's already a room with these coords";
+                return RedirectToAction("Create");
+            }
+
             var enemyRange = await _enemyService.GetRangeAsync(GetLevel("min"), GetLevel("max"));
             var room = new RoomCreateDto() { Details = roomDetails, EnemyRange = enemyRange };
             return View(room);

--- a/ShapeDungeon/Interfaces/Services/Rooms/IRoomCreateService.cs
+++ b/ShapeDungeon/Interfaces/Services/Rooms/IRoomCreateService.cs
@@ -8,5 +8,6 @@ namespace ShapeDungeon.Interfaces.Services.Rooms
     {
         Task<Room> CreateAsync(RoomDetailsDto roomDto);
         Task<RoomDetailsDto> InitializeRoomAsync(RoomDirection roomDirection);
+        Task<bool> AreCoordsInUse(int coordX, int coordY);
     }
 }

--- a/ShapeDungeon/Services/Rooms/RoomCreateService.cs
+++ b/ShapeDungeon/Services/Rooms/RoomCreateService.cs
@@ -2,7 +2,6 @@
 using ShapeDungeon.DTOs.Rooms;
 using ShapeDungeon.Entities;
 using ShapeDungeon.Helpers.Enums;
-using ShapeDungeon.Interfaces.Entity;
 using ShapeDungeon.Interfaces.Services.Rooms;
 using ShapeDungeon.Repos;
 
@@ -74,5 +73,8 @@ namespace ShapeDungeon.Services.Rooms
             roomDto.CoordY = coordY;
             return roomDto;
         }
+
+        public async Task<bool> AreCoordsInUse(int coordX, int coordY)
+            => await _roomRepository.GetByCoords(coordX, coordY) != null;
     }
 }

--- a/ShapeDungeon/Views/Room/Create.cshtml
+++ b/ShapeDungeon/Views/Room/Create.cshtml
@@ -20,6 +20,13 @@
     </div>
 </div>
 
+@if (@TempData["error"] != null)
+{
+    <script>
+        toastr.error("Bruh, you updated the URL manually, didn't you'? :D");
+    </script>
+}
+
 <script src=~/js/room/create.js></script>
 
 @if (Model.Details.IsActiveForEdit)


### PR DESCRIPTION
If the user updated the URL manually when creating a room to a direction that already has a room, they could still create a room.

This has now been fixed - the user is returned to the previous page and they get an error toast.