### PR TITLE
Player Selection

### DIFF
--- a/ShapeDungeon.Tests/ServiceTests/Players/PlayerCreateServiceTests.cs
+++ b/ShapeDungeon.Tests/ServiceTests/Players/PlayerCreateServiceTests.cs
@@ -1,0 +1,63 @@
+﻿#nullable disable
+using Moq;
+using NUnit.Framework;
+using ShapeDungeon.Data;
+using ShapeDungeon.DTOs.Players;
+using ShapeDungeon.Interfaces.Services.Players;
+using ShapeDungeon.Repos;
+using ShapeDungeon.Services.Players;
+using System.Threading.Tasks;
+
+namespace ShapeDungeon.Tests.ServiceTests.Players
+{
+    internal class PlayerCreateServiceTests
+    {
+        private Mock<IPlayerRepository> _repoMock;
+        private Mock<IUnitOfWork> _unitOfWorkMock;
+        private IPlayerCreateService _service;
+
+        [SetUp]
+        public void Test_Initialize()
+        {
+            _repoMock = new Mock<IPlayerRepository>();
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _service = new PlayerCreateService(_repoMock.Object, _unitOfWorkMock.Object);
+        }
+
+        [Test]
+        public async Task CreatePlayer_WithUniqueName_CreatesNewPlayer()
+        {
+            // Arrange
+            var uniqueName = "Minecraft Steve Lvl.64";
+            var playerDto = new PlayerDto { Name = uniqueName };
+
+            _repoMock
+                .Setup(x => x.DoesNameExist(playerDto.Name))
+                .ReturnsAsync(false);
+
+            // Act
+            var isCreated = await _service.CreatePlayerAsync(playerDto);
+
+            // Assert
+            Assert.IsTrue(isCreated);
+        }
+
+        [Test]
+        public async Task CreatePlayer_WithExistingName_DoesNotCreateNewPlayer()
+        {
+            // Arrange
+            var existingName = "Minecraft Steve Lvl.64";
+            var playerDto = new PlayerDto { Name = existingName };
+
+            _repoMock
+                .Setup(x => x.DoesNameExist(playerDto.Name))
+                .ReturnsAsync(true);
+
+            // Act
+            var isCreated = await _service.CreatePlayerAsync(playerDto);
+
+            // Assert
+            Assert.IsFalse(isCreated);
+        }
+    }
+}

--- a/ShapeDungeon.Tests/ServiceTests/Players/PlayerGetServiceTests.cs
+++ b/ShapeDungeon.Tests/ServiceTests/Players/PlayerGetServiceTests.cs
@@ -1,8 +1,6 @@
 ﻿#nullable disable
 using Moq;
 using NUnit.Framework;
-using ShapeDungeon.Data;
-using ShapeDungeon.DTOs.Players;
 using ShapeDungeon.Entities;
 using ShapeDungeon.Interfaces.Services.Players;
 using ShapeDungeon.Repos;
@@ -13,54 +11,16 @@ using System.Threading.Tasks;
 
 namespace ShapeDungeon.Tests.ServiceTests.Players
 {
-    internal class PlayerServiceTests
+    internal class PlayerGetServiceTests
     {
         private Mock<IPlayerRepository> _repoMock;
-        private Mock<IUnitOfWork> _unitOfWorkMock;
-        private IPlayerService _service;
+        private IPlayerGetService _service;
 
         [SetUp]
         public void Test_Initialize()
         {
             _repoMock = new Mock<IPlayerRepository>();
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _service = new PlayerService(_repoMock.Object, _unitOfWorkMock.Object);
-        }
-
-        [Test]
-        public async Task CreatePlayer_WithUniqueName_CreatesNewPlayer()
-        {
-            // Arrange
-            var uniqueName = "Minecraft Steve Lvl.64";
-            var playerDto = new PlayerDto { Name = uniqueName };
-
-            _repoMock
-                .Setup(x => x.DoesNameExist(playerDto.Name))
-                .ReturnsAsync(false);
-
-            // Act
-            var isCreated = await _service.CreatePlayerAsync(playerDto);
-
-            // Assert
-            Assert.IsTrue(isCreated);
-        }
-
-        [Test]
-        public async Task CreatePlayer_WithExistingName_DoesNotCreateNewPlayer()
-        {
-            // Arrange
-            var existingName = "Minecraft Steve Lvl.64";
-            var playerDto = new PlayerDto { Name = existingName };
-
-            _repoMock
-                .Setup(x => x.DoesNameExist(playerDto.Name))
-                .ReturnsAsync(true);
-
-            // Act
-            var isCreated = await _service.CreatePlayerAsync(playerDto);
-
-            // Assert
-            Assert.IsFalse(isCreated);
+            _service = new PlayerGetService(_repoMock.Object);
         }
 
         [Test]

--- a/ShapeDungeon/Controllers/HomeController.cs
+++ b/ShapeDungeon/Controllers/HomeController.cs
@@ -39,7 +39,7 @@ namespace ShapeDungeon.Controllers
             await _roomTravelService.IsScoutResetAsync(); // Doing this if player changes the URL manually.
             await _playerScoutService.UpdateActiveScoutEnergyAsync(PlayerScoutAction.Refill);
 
-            var player = await _playerGetService.GetPlayerAsync("Squary Lvl.8");
+            var player = await _playerGetService.GetActivePlayer();
             if (player == null)
             {
             }
@@ -69,7 +69,7 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Scouting()
         {
-            var player = await _playerGetService.GetPlayerAsync("Squary Lvl.8");
+            var player = await _playerGetService.GetActivePlayer();
             if (player == null)
             {
             }

--- a/ShapeDungeon/Controllers/HomeController.cs
+++ b/ShapeDungeon/Controllers/HomeController.cs
@@ -8,25 +8,25 @@ namespace ShapeDungeon.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly IPlayerService _playerService;
         private readonly IGetRoomService _getRoomService;
         private readonly IRoomEnemyService _roomEnemyService;
         private readonly IRoomTravelService _roomTravelService;
+        private readonly IPlayerGetService _playerGetService;
         private readonly IPlayerScoutService _playerScoutService;
         private readonly ICheckRoomNeighborsService _checkRoomNeighborsService;
 
         public HomeController(
-            IPlayerService playerService,
             IGetRoomService getRoomService,
             IRoomEnemyService roomEnemyService,
             IRoomTravelService roomTravelService,
+            IPlayerGetService playerGetService,
             IPlayerScoutService playerScoutService,
             ICheckRoomNeighborsService checkRoomNeighborsService)
         {
-            _playerService = playerService;
             _getRoomService = getRoomService;
             _roomEnemyService = roomEnemyService;
             _roomTravelService = roomTravelService;
+            _playerGetService = playerGetService;
             _playerScoutService = playerScoutService;
             _checkRoomNeighborsService = checkRoomNeighborsService;
         }
@@ -39,7 +39,7 @@ namespace ShapeDungeon.Controllers
             await _roomTravelService.IsScoutResetAsync(); // Doing this if player changes the URL manually.
             await _playerScoutService.UpdateActiveScoutEnergyAsync(PlayerScoutAction.Refill);
 
-            var player = await _playerService.GetPlayerAsync("Squary Lvl.8");
+            var player = await _playerGetService.GetPlayerAsync("Squary Lvl.8");
             if (player == null)
             {
             }
@@ -69,7 +69,7 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Scouting()
         {
-            var player = await _playerService.GetPlayerAsync("Squary Lvl.8");
+            var player = await _playerGetService.GetPlayerAsync("Squary Lvl.8");
             if (player == null)
             {
             }

--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -50,5 +50,12 @@ namespace ShapeDungeon.Controllers
             var activePlayer = await _playerGetService.GetActivePlayer();
             return View(activePlayer);
         }
+
+        [HttpGet]
+        public async Task<IActionResult> Select()
+        {
+            var playerList = await _playerGetService.GetAllPlayersAsync();
+            return View(playerList);
+        }
     }
 }

--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using ShapeDungeon.DTOs.Players;
+using ShapeDungeon.Helpers.Enums;
 using ShapeDungeon.Interfaces.Services.Players;
 
 namespace ShapeDungeon.Controllers
@@ -9,15 +10,18 @@ namespace ShapeDungeon.Controllers
         private readonly IPlayerCreateService _playerCreateService;
         private readonly IPlayerGetService _playerGetService;
         private readonly IPlayerSelectService _playerSelectService;
+        private readonly IPlayerUpdateService _playerUpdateService;
 
         public PlayerController(
             IPlayerCreateService playerCreateService,
-            IPlayerGetService playerGetService, 
-            IPlayerSelectService playerSelectService)
+            IPlayerGetService playerGetService,
+            IPlayerSelectService playerSelectService, 
+            IPlayerUpdateService playerUpdateService)
         {
             _playerCreateService = playerCreateService;
             _playerGetService = playerGetService;
             _playerSelectService = playerSelectService;
+            _playerUpdateService = playerUpdateService;
         }
 
         [HttpGet]
@@ -66,6 +70,13 @@ namespace ShapeDungeon.Controllers
         {
             await _playerSelectService.UpdateActivePlayer(newId);
             return RedirectToAction("Select");
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Increase(CharacterStat statToIncrease)
+        {
+            await _playerUpdateService.IncreaseStat(statToIncrease);
+            return RedirectToAction("Current");
         }
     }
 }

--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -6,17 +6,21 @@ namespace ShapeDungeon.Controllers
 {
     public class PlayerController : Controller
     {
-        private readonly IPlayerService _playerService;
+        private readonly IPlayerCreateService _playerCreateService;
+        private readonly IPlayerGetService _playerGetService;
 
-        public PlayerController(IPlayerService playerService)
+        public PlayerController(
+            IPlayerCreateService playerCreateService, 
+            IPlayerGetService playerGetService)
         {
-            _playerService = playerService;
+            _playerCreateService = playerCreateService;
+            _playerGetService = playerGetService;
         }
 
         [HttpGet]
         public async Task<IActionResult> Index()
         {
-            var playerList = await _playerService.GetAllPlayersAsync();
+            var playerList = await _playerGetService.GetAllPlayersAsync();
             if (playerList.Count() == 0)
                 return RedirectToAction("Create");
 
@@ -39,7 +43,7 @@ namespace ShapeDungeon.Controllers
                 return RedirectToAction("Create");
             }
 
-            var isCreated = await _playerService.CreatePlayerAsync(player);
+            var isCreated = await _playerCreateService.CreatePlayerAsync(player);
 
             if (!isCreated)
             {

--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -18,16 +18,6 @@ namespace ShapeDungeon.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> Index()
-        {
-            var playerList = await _playerGetService.GetAllPlayersAsync();
-            if (playerList.Count() == 0)
-                return RedirectToAction("Create");
-
-            return View(playerList);
-        }
-
-        [HttpGet]
         public IActionResult Create()
         {
             var model = new PlayerDto();
@@ -52,6 +42,13 @@ namespace ShapeDungeon.Controllers
             }
 
             return RedirectToAction("Active", "Home");
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Current()
+        {
+            var activePlayer = await _playerGetService.GetActivePlayer();
+            return View(activePlayer);
         }
     }
 }

--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -8,13 +8,16 @@ namespace ShapeDungeon.Controllers
     {
         private readonly IPlayerCreateService _playerCreateService;
         private readonly IPlayerGetService _playerGetService;
+        private readonly IPlayerSelectService _playerSelectService;
 
         public PlayerController(
-            IPlayerCreateService playerCreateService, 
-            IPlayerGetService playerGetService)
+            IPlayerCreateService playerCreateService,
+            IPlayerGetService playerGetService, 
+            IPlayerSelectService playerSelectService)
         {
             _playerCreateService = playerCreateService;
             _playerGetService = playerGetService;
+            _playerSelectService = playerSelectService;
         }
 
         [HttpGet]
@@ -56,6 +59,13 @@ namespace ShapeDungeon.Controllers
         {
             var playerList = await _playerGetService.GetAllPlayersAsync();
             return View(playerList);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Switch(Guid newId)
+        {
+            await _playerSelectService.UpdateActivePlayer(newId);
+            return RedirectToAction("Select");
         }
     }
 }

--- a/ShapeDungeon/DTOs/Players/PlayerGridDto.cs
+++ b/ShapeDungeon/DTOs/Players/PlayerGridDto.cs
@@ -6,6 +6,7 @@ namespace ShapeDungeon.DTOs.Players
     public class PlayerGridDto
     {
         public Guid Id { get; init; }
+        public bool IsActive { get; init; }
         public string Name { get; init; }
             = null!;
         public int Level { get; init; }
@@ -18,6 +19,7 @@ namespace ShapeDungeon.DTOs.Players
             => new()
             {
                 Id = player.Id,
+                IsActive = player.IsActive,
                 Name = player.Name,
                 Level = player.Level,
                 Strength = player.Strength,

--- a/ShapeDungeon/DTOs/Players/PlayerGridDto.cs
+++ b/ShapeDungeon/DTOs/Players/PlayerGridDto.cs
@@ -1,0 +1,29 @@
+﻿using ShapeDungeon.Entities;
+using ShapeDungeon.Entities.Enums;
+
+namespace ShapeDungeon.DTOs.Players
+{
+    public class PlayerGridDto
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; }
+            = null!;
+        public int Level { get; init; }
+        public int Strength { get; init; }
+        public int Vigor { get; init; }
+        public int Agility { get; init; }
+        public Shape Shape { get; init; }
+
+        public static implicit operator PlayerGridDto(Player player)
+            => new()
+            {
+                Id = player.Id,
+                Name = player.Name,
+                Level = player.Level,
+                Strength = player.Strength,
+                Vigor = player.Vigor,
+                Agility = player.Agility,
+                Shape = player.Shape,
+            };
+    }
+}

--- a/ShapeDungeon/Data/AppDbContext.cs
+++ b/ShapeDungeon/Data/AppDbContext.cs
@@ -42,7 +42,8 @@ namespace ShapeDungeon.Data
                 {
                     Id = new Guid("3DE35703-1FEF-4070-D75D-08DB4BEAC0A7"),
                     IsActive = true,
-                    Name = "Squary Lvl.8",
+                    Name = "Squary",
+                    Level = 8,
                     Strength = 2,
                     Vigor = 5,
                     Agility = 1,

--- a/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
+++ b/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IPlayerCreateService, PlayerCreateService>();
             services.AddScoped<IPlayerGetService, PlayerGetService>();
             services.AddScoped<IPlayerScoutService, PlayerScoutService>();
+            services.AddScoped<IPlayerSelectService, PlayerSelectService>();
 
             // Enemy
             services.AddScoped<IEnemyService, EnemyService>();

--- a/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
+++ b/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IDbContext, AppDbContext>();
 
             // Player
-            services.AddScoped<IPlayerService, PlayerService>();
+            services.AddScoped<IPlayerCreateService, PlayerCreateService>();
+            services.AddScoped<IPlayerGetService, PlayerGetService>();
             services.AddScoped<IPlayerScoutService, PlayerScoutService>();
 
             // Enemy

--- a/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
+++ b/ShapeDungeon/Helpers/AppServiceCollectionExtension.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IPlayerGetService, PlayerGetService>();
             services.AddScoped<IPlayerScoutService, PlayerScoutService>();
             services.AddScoped<IPlayerSelectService, PlayerSelectService>();
+            services.AddScoped<IPlayerUpdateService, PlayerUpdateService>();
 
             // Enemy
             services.AddScoped<IEnemyService, EnemyService>();

--- a/ShapeDungeon/Helpers/Enums/CharacterStat.cs
+++ b/ShapeDungeon/Helpers/Enums/CharacterStat.cs
@@ -1,0 +1,9 @@
+﻿namespace ShapeDungeon.Helpers.Enums
+{
+    public enum CharacterStat
+    {
+        Strength = 0,
+        Vigor = 1,
+        Agility = 2,
+    }
+}

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerCreateService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerCreateService.cs
@@ -2,10 +2,8 @@
 
 namespace ShapeDungeon.Interfaces.Services.Players
 {
-    public interface IPlayerService
+    public interface IPlayerCreateService
     {
         Task<bool> CreatePlayerAsync(PlayerDto pDto);
-        Task<IEnumerable<PlayerDto>> GetAllPlayersAsync();
-        Task<PlayerDto> GetPlayerAsync(string name);
     }
 }

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
@@ -1,0 +1,10 @@
+﻿using ShapeDungeon.DTOs.Players;
+
+namespace ShapeDungeon.Interfaces.Services.Players
+{
+    public interface IPlayerGetService
+    {
+        Task<IEnumerable<PlayerDto>> GetAllPlayersAsync();
+        Task<PlayerDto> GetPlayerAsync(string name);
+    }
+}

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
@@ -6,5 +6,6 @@ namespace ShapeDungeon.Interfaces.Services.Players
     {
         Task<IEnumerable<PlayerDto>> GetAllPlayersAsync();
         Task<PlayerDto> GetPlayerAsync(string name);
+        Task<PlayerDto> GetActivePlayer();
     }
 }

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
@@ -4,7 +4,7 @@ namespace ShapeDungeon.Interfaces.Services.Players
 {
     public interface IPlayerGetService
     {
-        Task<IEnumerable<PlayerDto>> GetAllPlayersAsync();
+        Task<IEnumerable<PlayerGridDto>> GetAllPlayersAsync();
         Task<PlayerDto> GetPlayerAsync(string name);
         Task<PlayerDto> GetActivePlayer();
     }

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerSelectService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerSelectService.cs
@@ -1,0 +1,7 @@
+﻿namespace ShapeDungeon.Interfaces.Services.Players
+{
+    public interface IPlayerSelectService
+    {
+        Task UpdateActivePlayer(Guid newActivePlayerId);
+    }
+}

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerUpdateService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerUpdateService.cs
@@ -1,0 +1,9 @@
+﻿using ShapeDungeon.Helpers.Enums;
+
+namespace ShapeDungeon.Interfaces.Services.Players
+{
+    public interface IPlayerUpdateService
+    {
+        Task IncreaseStat(CharacterStat statToIncrease);
+    }
+}

--- a/ShapeDungeon/Migrations/20230626152247_FixSeededPlayerLevel.Designer.cs
+++ b/ShapeDungeon/Migrations/20230626152247_FixSeededPlayerLevel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -10,9 +11,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230626152247_FixSeededPlayerLevel")]
+    partial class FixSeededPlayerLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.16");
@@ -157,7 +159,7 @@ namespace ShapeDungeon.Migrations
                             ExpToNextLevel = 100,
                             IsActive = true,
                             Level = 8,
-                            Name = "Squary",
+                            Name = "Squary Lvl.8",
                             Shape = 0,
                             Strength = 2,
                             Vigor = 5

--- a/ShapeDungeon/Migrations/20230626152247_FixSeededPlayerLevel.cs
+++ b/ShapeDungeon/Migrations/20230626152247_FixSeededPlayerLevel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class FixSeededPlayerLevel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Players",
+                keyColumn: "Id",
+                keyValue: new Guid("3de35703-1fef-4070-d75d-08db4beac0a7"),
+                column: "Level",
+                value: 8);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Players",
+                keyColumn: "Id",
+                keyValue: new Guid("3de35703-1fef-4070-d75d-08db4beac0a7"),
+                column: "Level",
+                value: 0);
+        }
+    }
+}

--- a/ShapeDungeon/Migrations/20230626152504_FixSeededPlayerName.Designer.cs
+++ b/ShapeDungeon/Migrations/20230626152504_FixSeededPlayerName.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShapeDungeon.Data;
 
@@ -10,9 +11,10 @@ using ShapeDungeon.Data;
 namespace ShapeDungeon.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230626152504_FixSeededPlayerName")]
+    partial class FixSeededPlayerName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.16");

--- a/ShapeDungeon/Migrations/20230626152504_FixSeededPlayerName.cs
+++ b/ShapeDungeon/Migrations/20230626152504_FixSeededPlayerName.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShapeDungeon.Migrations
+{
+    public partial class FixSeededPlayerName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Players",
+                keyColumn: "Id",
+                keyValue: new Guid("3de35703-1fef-4070-d75d-08db4beac0a7"),
+                column: "Name",
+                value: "Squary");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Players",
+                keyColumn: "Id",
+                keyValue: new Guid("3de35703-1fef-4070-d75d-08db4beac0a7"),
+                column: "Name",
+                value: "Squary Lvl.8");
+        }
+    }
+}

--- a/ShapeDungeon/Repos/IPlayerRepository.cs
+++ b/ShapeDungeon/Repos/IPlayerRepository.cs
@@ -25,6 +25,12 @@ namespace ShapeDungeon.Repos
         Task<Player?> GetByName(string name);
 
         /// <summary>
+        /// </summary>
+        /// <param name="id">Id of the player that we want to return.</param>
+        /// <returns>Player with matching id or null.</returns>
+        Task<Player?> GetById(Guid id);
+
+        /// <summary>
         /// Many players can be present and selected.
         /// </summary>
         /// <returns>List of all created players.</returns>

--- a/ShapeDungeon/Repos/PlayerRepository.cs
+++ b/ShapeDungeon/Repos/PlayerRepository.cs
@@ -37,6 +37,13 @@ namespace ShapeDungeon.Repos
             => await this.Context.Players.FirstOrDefaultAsync(x => x.Name == name);
 
         /// <summary>
+        /// </summary>
+        /// <param name="id">Id of the player that we want to return.</param>
+        /// <returns>Player with matching id or null.</returns>
+        public async Task<Player?> GetById(Guid id)
+            => await this.Context.Players.FirstOrDefaultAsync(x => x.Id == id);
+
+        /// <summary>
         /// Many players can be present and selected.
         /// </summary>
         /// <returns>List of all created players.</returns>

--- a/ShapeDungeon/Services/Enemies/EnemyService.cs
+++ b/ShapeDungeon/Services/Enemies/EnemyService.cs
@@ -45,10 +45,7 @@ namespace ShapeDungeon.Services.Enemies
             var enemyDtos = new List<EnemyRangeDto>();
 
             foreach (var enemy in enemies)
-            {
-                EnemyRangeDto enemyDto = enemy;
-                enemyDtos.Add(enemyDto);
-            }
+                enemyDtos.Add(enemy);
 
             return enemyDtos;
         }

--- a/ShapeDungeon/Services/Players/PlayerCreateService.cs
+++ b/ShapeDungeon/Services/Players/PlayerCreateService.cs
@@ -6,12 +6,12 @@ using ShapeDungeon.Repos;
 
 namespace ShapeDungeon.Services.Players
 {
-    public class PlayerService : IPlayerService
+    public class PlayerCreateService : IPlayerCreateService
     {
         private readonly IPlayerRepository _playerRepository;
         private readonly IUnitOfWork _unitOfWork;
 
-        public PlayerService( 
+        public PlayerCreateService( 
             IPlayerRepository playerRepository, 
             IUnitOfWork unitOfWork)
         {
@@ -49,31 +49,6 @@ namespace ShapeDungeon.Services.Players
 
             doesNameExist = true;
             return doesNameExist;
-        }
-
-        public async Task<IEnumerable<PlayerDto>> GetAllPlayersAsync()
-        {
-            var players = await _playerRepository.GetAll();
-            var playersDto = new List<PlayerDto>();
-
-            foreach (var player in players)
-            {
-                PlayerDto playerDto = player;
-                playersDto.Add(playerDto);
-            }
-
-            return playersDto;
-        }
-
-        public async Task<PlayerDto> GetPlayerAsync(string name)
-        {
-            var player = await _playerRepository.GetByName(name);
-            var playerDto = new PlayerDto();
-
-            if (player != null)
-               playerDto = player;
-
-            return playerDto;
         }
     }
 }

--- a/ShapeDungeon/Services/Players/PlayerCreateService.cs
+++ b/ShapeDungeon/Services/Players/PlayerCreateService.cs
@@ -34,7 +34,7 @@ namespace ShapeDungeon.Services.Players
                 Strength = pDto.Strength,
                 Vigor = pDto.Vigor,
                 Agility = pDto.Agility,
-                Level = 1,
+                Level = pDto.Strength + pDto.Vigor + pDto.Agility,
                 CurrentExp = 0,
                 ExpToNextLevel = 100,
                 CurrentSkillpoints = 0,

--- a/ShapeDungeon/Services/Players/PlayerGetService.cs
+++ b/ShapeDungeon/Services/Players/PlayerGetService.cs
@@ -37,5 +37,8 @@ namespace ShapeDungeon.Services.Players
 
             return playerDto;
         }
+
+        public async Task<PlayerDto> GetActivePlayer()
+            => await _playerRepository.GetActive();
     }
 }

--- a/ShapeDungeon/Services/Players/PlayerGetService.cs
+++ b/ShapeDungeon/Services/Players/PlayerGetService.cs
@@ -18,11 +18,8 @@ namespace ShapeDungeon.Services.Players
             var players = await _playerRepository.GetAll();
             var playersDto = new List<PlayerGridDto>();
 
-            foreach (var player in players)
-            {
-                PlayerGridDto playerDto = player;
-                playersDto.Add(playerDto);
-            }
+            foreach (var player in players) 
+                playersDto.Add(player);
 
             return playersDto;
         }

--- a/ShapeDungeon/Services/Players/PlayerGetService.cs
+++ b/ShapeDungeon/Services/Players/PlayerGetService.cs
@@ -1,0 +1,41 @@
+﻿using ShapeDungeon.DTOs.Players;
+using ShapeDungeon.Interfaces.Services.Players;
+using ShapeDungeon.Repos;
+
+namespace ShapeDungeon.Services.Players
+{
+    public class PlayerGetService : IPlayerGetService
+    {
+        private readonly IPlayerRepository _playerRepository;
+
+        public PlayerGetService(IPlayerRepository playerRepository)
+        {
+            _playerRepository = playerRepository;
+        }
+
+        public async Task<IEnumerable<PlayerDto>> GetAllPlayersAsync()
+        {
+            var players = await _playerRepository.GetAll();
+            var playersDto = new List<PlayerDto>();
+
+            foreach (var player in players)
+            {
+                PlayerDto playerDto = player;
+                playersDto.Add(playerDto);
+            }
+
+            return playersDto;
+        }
+
+        public async Task<PlayerDto> GetPlayerAsync(string name)
+        {
+            var player = await _playerRepository.GetByName(name);
+            var playerDto = new PlayerDto();
+
+            if (player != null)
+               playerDto = player;
+
+            return playerDto;
+        }
+    }
+}

--- a/ShapeDungeon/Services/Players/PlayerGetService.cs
+++ b/ShapeDungeon/Services/Players/PlayerGetService.cs
@@ -13,14 +13,14 @@ namespace ShapeDungeon.Services.Players
             _playerRepository = playerRepository;
         }
 
-        public async Task<IEnumerable<PlayerDto>> GetAllPlayersAsync()
+        public async Task<IEnumerable<PlayerGridDto>> GetAllPlayersAsync()
         {
             var players = await _playerRepository.GetAll();
-            var playersDto = new List<PlayerDto>();
+            var playersDto = new List<PlayerGridDto>();
 
             foreach (var player in players)
             {
-                PlayerDto playerDto = player;
+                PlayerGridDto playerDto = player;
                 playersDto.Add(playerDto);
             }
 

--- a/ShapeDungeon/Services/Players/PlayerSelectService.cs
+++ b/ShapeDungeon/Services/Players/PlayerSelectService.cs
@@ -1,0 +1,37 @@
+﻿using ShapeDungeon.Data;
+using ShapeDungeon.Interfaces.Services.Players;
+using ShapeDungeon.Repos;
+
+namespace ShapeDungeon.Services.Players
+{
+    public class PlayerSelectService : IPlayerSelectService
+    {
+        private readonly IPlayerRepository _playerRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public PlayerSelectService(
+            IPlayerRepository playerRepository, 
+            IUnitOfWork unitOfWork)
+        {
+            _playerRepository = playerRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task UpdateActivePlayer(Guid newActivePlayerId)
+        {
+            var oldActivePlayer = await _playerRepository.GetActive();
+            if (oldActivePlayer != null)
+            {
+                var newActivePlayer = await _playerRepository.GetById(newActivePlayerId);
+                if (newActivePlayer != null)
+                {
+                    await _unitOfWork.Commit(() =>
+                    {
+                        oldActivePlayer.IsActive = false;
+                        newActivePlayer.IsActive = true;
+                    });
+                }
+            }
+        }
+    }
+}

--- a/ShapeDungeon/Services/Players/PlayerUpdateService.cs
+++ b/ShapeDungeon/Services/Players/PlayerUpdateService.cs
@@ -1,0 +1,47 @@
+﻿using ShapeDungeon.Data;
+using ShapeDungeon.Helpers.Enums;
+using ShapeDungeon.Interfaces.Services.Players;
+using ShapeDungeon.Repos;
+
+namespace ShapeDungeon.Services.Players
+{
+    public class PlayerUpdateService : IPlayerUpdateService
+    {
+        private readonly IPlayerRepository _playerRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public PlayerUpdateService(
+            IPlayerRepository playerRepository, 
+            IUnitOfWork unitOfWork)
+        {
+            _playerRepository = playerRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        // Haduken code created lol
+        // After error handling middleware is implemented this will be fixed, hopefully :D
+        public async Task IncreaseStat(CharacterStat statToIncrease)
+        {
+            var activePlayer = await _playerRepository.GetActive();
+            if (activePlayer != null)
+            {
+                if (activePlayer.CurrentSkillpoints > 0)
+                {
+                    await _unitOfWork.Commit(() =>
+                    {
+                        switch (statToIncrease)
+                        {
+                            case CharacterStat.Strength: activePlayer.Strength++; break;
+                            case CharacterStat.Vigor: activePlayer.Vigor++; break;
+                            case CharacterStat.Agility: activePlayer.Agility++; break;
+                            default: throw new ArgumentOutOfRangeException(statToIncrease.ToString());
+                        }
+
+                        activePlayer.CurrentSkillpoints--;
+                        activePlayer.Level++;
+                    });
+                }
+            }
+        }
+    }
+}

--- a/ShapeDungeon/Views/Home/_Player.cshtml
+++ b/ShapeDungeon/Views/Home/_Player.cshtml
@@ -22,7 +22,7 @@
     {
         <div id="player"
          class="position-absolute top-50 start-50 translate-middle"
-         style="height:10rem;width:10rem;background-color:limegreen;border-radius:50%">
+         style="height:9.5rem;width:9.5rem;background-color:limegreen;border-radius:50%">
         </div>
     }
     <partial name="_ScoutEnergy" />

--- a/ShapeDungeon/Views/Home/_Player.cshtml
+++ b/ShapeDungeon/Views/Home/_Player.cshtml
@@ -6,24 +6,15 @@
 <td class="align-middle position-relative" style="width:50vw">
     @if (Model.Shape == Shape.Square)
     {
-        <div id="player"
-         class="position-absolute top-50 start-50 translate-middle"
-         style="height:7.5rem;width:7.5rem;background-color:limegreen">
-        </div>
+        <partial name="_ShapeSquarePlayer" />
     }
     else if (Model.Shape == Shape.Triangle)
     {
-        <div id="player"
-         class="position-absolute top-50 start-50 translate-middle"
-         style="width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid limegreen;border-bottom: 5rem solid transparent">
-        </div>
+        <partial name="_ShapeTrianglePlayer" />
     }
     else if (Model.Shape == Shape.Circle)
     {
-        <div id="player"
-         class="position-absolute top-50 start-50 translate-middle"
-         style="height:9.5rem;width:9.5rem;background-color:limegreen;border-radius:50%">
-        </div>
+        <partial name="_ShapeCirclePlayer" />
     }
     <partial name="_ScoutEnergy" />
 </td>

--- a/ShapeDungeon/Views/Player/Create.cshtml
+++ b/ShapeDungeon/Views/Player/Create.cshtml
@@ -1,5 +1,4 @@
 ﻿@using ShapeDungeon.DTOs.Players;
-
 @model PlayerDto
 
 @{
@@ -8,7 +7,7 @@
 
 <div class="container" style="width:100vw;height:75vh">
     <div class="row text-center mt-4" style="height:10%">
-        <h2>Create Player</h2>
+        <h2>@ViewBag.Title</h2>
     </div>
     <div class="row align-items-center" style="height:80%">
         <form method="post" class="col-sm-6">

--- a/ShapeDungeon/Views/Player/Current.cshtml
+++ b/ShapeDungeon/Views/Player/Current.cshtml
@@ -49,9 +49,11 @@
 
             <hr class="border-3 border-top border-success">
 
-            <div class="btn-group" role="group" aria-label="@Model.Name's Shape:" style="width:100%">
+            <div class="btn-group" role="group" aria-label="@Model.Name Extra Info:" style="width:100%">
                 <input type="radio" class="btn-check" id="player-shape" checked>
-                <label class="btn btn-outline-success" style="cursor:default" for="square">@Model.Shape</label>
+                <label class="btn btn-outline-success" style="cursor:default" for="shape">@Model.Shape</label>
+                <input type="radio" class="btn-check" id="player-level">
+                <label class="btn btn-outline-info" style="cursor:default" for="level">Lvl.@Model.Level</label>
             </div>
 
             <hr class="border-3 border-top border-success">

--- a/ShapeDungeon/Views/Player/Current.cshtml
+++ b/ShapeDungeon/Views/Player/Current.cshtml
@@ -1,0 +1,106 @@
+﻿@using ShapeDungeon.DTOs.Players
+@model PlayerDto
+
+@{
+    ViewBag.Title = "Current Player";
+}
+
+<link rel="stylesheet" href="~/css/buttons-small.css" />
+<link rel="stylesheet" href="~/css/player-stats.css" />
+
+<div id="stat-confirmation" class="hidden" style="position:absolute">
+    <div id="confirmation-window">
+        <h3>Are you sure you want to increase <span id="stat-name">STAT</span> by 1?</h3>
+        <a id="strength-yes-btn" class="btn btn-outline-success stat-btn hidden"
+        asp-controller="Player" asp-action="Bruhy Strength">
+            Yes
+        </a>
+        <a id="vigor-yes-btn" class="btn btn-outline-success stat-btn hidden"
+        asp-controller="Player" asp-action="Bruhy Vigor">
+            Yes
+        </a>
+        <a id="agility-yes-btn" class="btn btn-outline-success stat-btn hidden"
+        asp-controller="Player" asp-action="Bruhy Agility">
+            Yes
+        </a>
+        <a id="no-btn" class="btn btn-outline-danger stat-btn">No</a>
+    </div>
+</div>
+
+<div class="container" style="width:100vw;height:75vh">
+    <div class="row text-center mt-4" style="height:10%">
+        <h2>@ViewBag.Title</h2>
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="fast-level-up-switch">
+            <label class="form-check-label" for="fast-level-up-switch">Fast Stat Upgrade</label>
+        </div>
+    </div>
+    <div class="row align-items-center" style="height:80%">
+        <div class="col-sm-6">
+            <div class="form-group row">
+                <input type="text" id="player-name" class="form-control text-center" style="background:white!important"
+                asp-for="@Model.Name" disabled />
+            </div>
+
+            <hr class="border-3 border-top border-success">
+
+            <div class="btn-group" role="group" aria-label="@Model.Name's Shape:" style="width:100%">
+                <input type="radio" class="btn-check" id="player-shape" checked>
+                <label class="btn btn-outline-success" style="cursor:default" for="square">@Model.Shape</label>
+            </div>
+
+            <hr class="border-3 border-top border-success">
+
+            <div id="bar-text">
+                <span class="small-bar-text">(Current Exp)</span>
+                <span class="bar-heading">Current Skillpoints: @Model.CurrentSkillpoints</span>
+                <span class="small-bar-text">(Exp to Next Level)</span>
+            </div>
+            <div class="progress position-relative" style="width:100%">
+                <div class="progress-bar bg-success" role="progressbar" id="level-bar"
+                     aria-valuenow="@Model.CurrentExp" aria-valuemin="0" aria-valuemax="@Model.ExpToNextLevel">
+                </div>
+                <span class="position-absolute" id="curr-xp" style="right:95%;color:lightgray">@Model.CurrentExp</span>
+                <span class="position-absolute" id="required-xp" style="left:95%;color:white">@Model.ExpToNextLevel</span>
+            </div>
+
+            <hr class="border-3 border-top border-success">
+
+            <div style="display:flex;justify-content:space-between;align-items:center">
+                <label class="stat-text" for="strength">Strength:</label>
+                <div>
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="strength" asp-for="@Model.Strength" value="2">
+                </div>
+                <a id="strength-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
+
+                <label class="stat-text" for="vigor">Vigor:</label>
+                <div>
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="vigor" asp-for="@Model.Vigor" value="5">
+                </div>
+                <a id="vigor-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
+
+                <label class="stat-text" for="agility">Agility:</label>
+                <div>
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="agility" asp-for="@Model.Agility" value="1">
+                </div>
+                <a id="agility-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
+            </div>
+        </div>
+
+        <div class="col-sm-5 position-relative">
+            <div id="selected-shape"
+                 style="height:10rem;width:10rem;background-color:limegreen"
+                 class="position-absolute top-50 start-50 translate-middle">
+            </div>
+        </div>
+    </div>
+</div>
+
+@*TODO: Turn scripts into bundle files.*@
+<script src="~/js/player/level-bar.js"></script>
+<script src="~/js/player/toggle-skillpoint-btns.js"></script>
+<script src="~/js/player/level-up-skill.js" type="module"></script>
+<script>
+    updateBar(@Model.CurrentExp, @Model.ExpToNextLevel);
+    toggleSkillpointBtns(@Model.CurrentSkillpoints);
+</script>

--- a/ShapeDungeon/Views/Player/Current.cshtml
+++ b/ShapeDungeon/Views/Player/Current.cshtml
@@ -1,5 +1,6 @@
 ﻿@using ShapeDungeon.DTOs.Players
 @using ShapeDungeon.Entities.Enums
+@using ShapeDungeon.Helpers.Enums
 @model PlayerDto
 
 @{
@@ -13,15 +14,15 @@
     <div id="confirmation-window">
         <h3>Are you sure you want to increase <span id="stat-name">STAT</span> by 1?</h3>
         <a id="strength-yes-btn" class="btn btn-outline-success stat-btn hidden"
-        asp-controller="Player" asp-action="Bruhy Strength">
+        asp-controller="Player" asp-action="Increase" asp-route-statToIncrease="@CharacterStat.Strength">
             Yes
         </a>
         <a id="vigor-yes-btn" class="btn btn-outline-success stat-btn hidden"
-        asp-controller="Player" asp-action="Bruhy Vigor">
+        asp-controller="Player" asp-action="Increase" asp-route-statToIncrease="@CharacterStat.Vigor">
             Yes
         </a>
         <a id="agility-yes-btn" class="btn btn-outline-success stat-btn hidden"
-        asp-controller="Player" asp-action="Bruhy Agility">
+        asp-controller="Player" asp-action="Increase" asp-route-statToIncrease="@CharacterStat.Agility">
             Yes
         </a>
         <a id="no-btn" class="btn btn-outline-danger stat-btn">No</a>
@@ -73,19 +74,19 @@
             <div style="display:flex;justify-content:space-between;align-items:center">
                 <label class="stat-text" for="strength">Strength:</label>
                 <div>
-                    <input type="text" readonly class="form-control-plaintext stat-number" id="strength" asp-for="@Model.Strength" value="2">
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="strength" asp-for="@Model.Strength" value="@Model.Strength">
                 </div>
                 <a id="strength-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
 
                 <label class="stat-text" for="vigor">Vigor:</label>
                 <div>
-                    <input type="text" readonly class="form-control-plaintext stat-number" id="vigor" asp-for="@Model.Vigor" value="5">
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="vigor" asp-for="@Model.Vigor" value="@Model.Vigor">
                 </div>
                 <a id="vigor-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
 
                 <label class="stat-text" for="agility">Agility:</label>
                 <div>
-                    <input type="text" readonly class="form-control-plaintext stat-number" id="agility" asp-for="@Model.Agility" value="1">
+                    <input type="text" readonly class="form-control-plaintext stat-number" id="agility" asp-for="@Model.Agility" value="@Model.Agility">
                 </div>
                 <a id="agility-plus" class="btn btn-outline-success btn-small stat-btn">+</a>
             </div>

--- a/ShapeDungeon/Views/Player/Current.cshtml
+++ b/ShapeDungeon/Views/Player/Current.cshtml
@@ -1,4 +1,5 @@
 ﻿@using ShapeDungeon.DTOs.Players
+@using ShapeDungeon.Entities.Enums
 @model PlayerDto
 
 @{
@@ -91,10 +92,18 @@
         </div>
 
         <div class="col-sm-5 position-relative">
-            <div id="selected-shape"
-                 style="height:10rem;width:10rem;background-color:limegreen"
-                 class="position-absolute top-50 start-50 translate-middle">
-            </div>
+            @if (Model.Shape == Shape.Square)
+            {
+                <partial name="_ShapeSquarePlayer" />
+            }
+            else if (Model.Shape == Shape.Triangle)
+            {
+                <partial name="_ShapeTrianglePlayer" />
+            }
+            else if (Model.Shape == Shape.Circle)
+            {
+                <partial name="_ShapeCirclePlayer" />
+            }
         </div>
     </div>
 </div>

--- a/ShapeDungeon/Views/Player/Current.cshtml
+++ b/ShapeDungeon/Views/Player/Current.cshtml
@@ -34,6 +34,9 @@
             <input class="form-check-input" type="checkbox" id="fast-level-up-switch">
             <label class="form-check-label" for="fast-level-up-switch">Fast Stat Upgrade</label>
         </div>
+        <p id="f-switch-info">
+            (toggle to skip confirmation on stat level up)
+        </p>
     </div>
     <div class="row align-items-center" style="height:80%">
         <div class="col-sm-6">

--- a/ShapeDungeon/Views/Player/Select.cshtml
+++ b/ShapeDungeon/Views/Player/Select.cshtml
@@ -21,7 +21,9 @@
             }
             else
             {
-                <a class="inactive-name">@player.Name</a>
+                <a class="inactive-name" asp-controller="Player" asp-action="Switch" asp-route-newId="@player.Id">
+                    @player.Name
+                </a>
             }
 
             @switch (player.Shape)

--- a/ShapeDungeon/Views/Player/Select.cshtml
+++ b/ShapeDungeon/Views/Player/Select.cshtml
@@ -7,7 +7,10 @@
 }
 
 <link rel="stylesheet" href="~/css/player/grid.css" />
-<h2 style="text-align:center;margin-bottom:2rem">@ViewBag.Title</h2>
+<h2 style="text-align:center;margin-bottom:0">@ViewBag.Title</h2>
+<p style="text-align:center;margin-bottom:2rem;font-style:italic;font-size:0.65rem;">
+    (by clicking on a name)
+</p>
 <div class="selection-grid">
     @foreach (var player in Model)
     {
@@ -18,7 +21,7 @@
             }
             else
             {
-                <h6 style="color:#a8a8a8">@player.Name</h6>
+                <a class="inactive-name">@player.Name</a>
             }
 
             @switch (player.Shape)
@@ -41,7 +44,14 @@
                     break;
             }
 
-            <h4>Lvl.@player.Level</h4>
+            @if (player.IsActive)
+            {
+                <h4>Lvl.@player.Level</h4>
+            }
+            else
+            {
+                <h6 style="color:#a8a8a8">Lvl.@player.Level</h6>
+            }
         </div>
     }
 </div>

--- a/ShapeDungeon/Views/Player/Select.cshtml
+++ b/ShapeDungeon/Views/Player/Select.cshtml
@@ -17,7 +17,14 @@
         <div class="player-card">
             @if (player.IsActive)
             {
-                <h4>@player.Name</h4>
+                if (player.Name.Length > 16)
+                {
+                    <h4 class="active-name small">@player.Name</h4>
+                }
+                else
+                {
+                    <h4 class="active-name">@player.Name</h4>
+                }
             }
             else
             {

--- a/ShapeDungeon/Views/Player/Select.cshtml
+++ b/ShapeDungeon/Views/Player/Select.cshtml
@@ -1,0 +1,47 @@
+﻿@using ShapeDungeon.DTOs.Players
+@using ShapeDungeon.Entities.Enums
+@model IEnumerable<PlayerGridDto>
+
+@{
+    ViewBag.Title = "Select Player";
+}
+
+<link rel="stylesheet" href="~/css/player/grid.css" />
+<h2 style="text-align:center;margin-bottom:2rem">@ViewBag.Title</h2>
+<div class="selection-grid">
+    @foreach (var player in Model)
+    {
+        <div class="player-card">
+            @if (player.IsActive)
+            {
+                <h4>@player.Name</h4>
+            }
+            else
+            {
+                <h6 style="color:#a8a8a8">@player.Name</h6>
+            }
+
+            @switch (player.Shape)
+            {
+                case Shape.Square:
+                    <div id="@player.Id"
+                        style="height:10rem;width:10rem;background-color:limegreen">
+                    </div>
+                    break;
+                case Shape.Triangle:
+                    <div id="@player.Id"
+                        style="width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid limegreen;border-bottom: 5rem solid transparent">
+                    </div>
+                    break;
+                case Shape.Circle:
+                default:
+                    <div id="@player.Id"
+                        style="height:10rem;width:10rem;background-color:limegreen;border-radius:50%">
+                    </div>
+                    break;
+            }
+
+            <h4>Lvl.@player.Level</h4>
+        </div>
+    }
+</div>

--- a/ShapeDungeon/Views/Room/_EnemyForm.cshtml
+++ b/ShapeDungeon/Views/Room/_EnemyForm.cshtml
@@ -50,4 +50,4 @@
     <hr class="border-3 border-top border-success">
 </div>
 
-<script src=~/js/enemy/range.js></script>
+<script src="~/js/enemy/range.js" type="module"></script>

--- a/ShapeDungeon/Views/Shared/_Layout.cshtml
+++ b/ShapeDungeon/Views/Shared/_Layout.cshtml
@@ -29,8 +29,15 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Active">Go to Active Room</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Player" asp-action="Create">Create Player</a>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle bttr-dropdown" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                                Player
+                            </a>
+                            <div class="dropdown-menu" style="">
+                                <a class="dropdown-item" asp-controller="Player" asp-action="Current">Current Player</a>
+                                <a class="dropdown-item" asp-controller="Player" asp-action="Select">Select Player</a>
+                                <a class="dropdown-item" asp-controller="Player" asp-action="Create">Create Player</a>
+                            </div>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Room" asp-action="Create">Create Room</a>

--- a/ShapeDungeon/Views/Shared/_ShapeCirclePlayer.cshtml
+++ b/ShapeDungeon/Views/Shared/_ShapeCirclePlayer.cshtml
@@ -1,0 +1,4 @@
+﻿<div id="selected-shape"
+     class="position-absolute top-50 start-50 translate-middle"
+     style="height:9.5rem;width:9.5rem;background-color:limegreen;border-radius:50%">
+</div>

--- a/ShapeDungeon/Views/Shared/_ShapeSquarePlayer.cshtml
+++ b/ShapeDungeon/Views/Shared/_ShapeSquarePlayer.cshtml
@@ -1,0 +1,4 @@
+﻿<div id="selected-shape"
+     class="position-absolute top-50 start-50 translate-middle"
+     style="height:9.5rem;width:9.5rem;background-color:limegreen">
+</div>

--- a/ShapeDungeon/Views/Shared/_ShapeTrianglePlayer.cshtml
+++ b/ShapeDungeon/Views/Shared/_ShapeTrianglePlayer.cshtml
@@ -1,0 +1,4 @@
+﻿<div id="selected-shape"
+     class="position-absolute top-50 start-50 translate-middle"
+     style="width:0;height:0;border-top: 5rem solid transparent;border-left: 10rem solid limegreen;border-bottom: 5rem solid transparent">
+</div>

--- a/ShapeDungeon/wwwroot/css/buttons-small.css
+++ b/ShapeDungeon/wwwroot/css/buttons-small.css
@@ -1,0 +1,6 @@
+﻿.btn-small {
+    width: 5%;
+    padding: 0;
+    margin: auto;
+    text-align: center;
+}

--- a/ShapeDungeon/wwwroot/css/player-stats.css
+++ b/ShapeDungeon/wwwroot/css/player-stats.css
@@ -4,6 +4,12 @@
     gap: 0.5rem;
 }
 
+#f-switch-info {
+    font-style: italic;
+    font-size: 0.6rem;
+    color: dimgray;
+}
+
 .stat-text {
     margin-right: 1rem;
 }

--- a/ShapeDungeon/wwwroot/css/player-stats.css
+++ b/ShapeDungeon/wwwroot/css/player-stats.css
@@ -1,0 +1,65 @@
+﻿.form-switch {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.stat-text {
+    margin-right: 1rem;
+}
+
+.stat-number {
+    margin-right: 0.5rem;
+    width: 1rem;
+}
+
+.stat-btn {
+    margin: 0;
+}
+
+#bar-text {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.small-bar-text, .bar-heading {
+    font-style: italic;
+}
+
+.small-bar-text {
+    font-size: 0.65rem;
+    color: dimgray;
+}
+
+#stat-confirmation {
+    transform: translate(-50%, -50%);
+    justify-content: center;
+    align-items: center;
+    background: #060606;
+    text-align: center;
+    display: flex;
+    z-index: 100;
+    height: 75vh;
+    width: 90vw;
+    left: 50%;
+    top: 50%;
+}
+
+#stat-confirmation h3 {
+    margin: auto;
+    margin-bottom: 2.5rem;
+    width: 50vw;
+}
+
+#stat-confirmation a {
+    width: 45vw;
+}
+
+.stat-btn {
+    margin-bottom: 0.25rem;
+}
+
+.hidden {
+    display: none!important;
+}

--- a/ShapeDungeon/wwwroot/css/player/grid.css
+++ b/ShapeDungeon/wwwroot/css/player/grid.css
@@ -17,14 +17,24 @@
     width: 25%;
 }
 
-.player-card h6 {
+.player-card div {
+    margin-bottom: 0.5rem;
+}
+
+.inactive-name {
+    transition: font-size 0.5s;
     word-wrap: break-word;
+    text-decoration: none;
     text-align: center;
+    font-size: 1rem;
+    cursor: pointer;
+    color: #a8a8a8;
     width: 100%;
 }
 
-.player-card div {
-    margin-bottom: 0.5rem;
+.inactive-name:hover {
+    font-size: 1.25rem;
+    color: #d1d1d1;
 }
 
 .selection-grid::-webkit-scrollbar {

--- a/ShapeDungeon/wwwroot/css/player/grid.css
+++ b/ShapeDungeon/wwwroot/css/player/grid.css
@@ -21,6 +21,16 @@
     margin-bottom: 0.5rem;
 }
 
+.active-name {
+    word-wrap: break-word;
+    text-align: center;
+    width: 100%;
+}
+
+.active-name.small {
+    font-size: 1.25rem;
+}
+
 .inactive-name {
     transition: font-size 0.5s;
     word-wrap: break-word;

--- a/ShapeDungeon/wwwroot/css/player/grid.css
+++ b/ShapeDungeon/wwwroot/css/player/grid.css
@@ -1,0 +1,59 @@
+﻿.selection-grid {
+    justify-content: center;
+    flex-direction: row;
+    align-items: center;
+    overflow-y: scroll;
+    flex-wrap: wrap;
+    display: flex;
+    height: 60vh;
+    width: 80vw;
+}
+
+.player-card {
+    flex-direction: column;
+    margin-bottom: 2rem;
+    align-items: center;
+    display: flex;
+    width: 25%;
+}
+
+.player-card h6 {
+    word-wrap: break-word;
+    text-align: center;
+    width: 100%;
+}
+
+.player-card div {
+    margin-bottom: 0.5rem;
+}
+
+.selection-grid::-webkit-scrollbar {
+    width: 6px;
+    width: 6px;
+}
+
+.selection-grid::-webkit-scrollbar-track {
+    border-radius: 4px;
+    background-color: #ABB2B3;
+}
+
+.selection-grid::-webkit-scrollbar-track:hover {
+    background-color: #929898;
+}
+
+.selection-grid::-webkit-scrollbar-track:active {
+    background-color: #989E9F;
+}
+
+.selection-grid::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background-color: #249924;
+}
+
+.selection-grid::-webkit-scrollbar-thumb:hover {
+    background-color: #229022;
+}
+
+.selection-grid::-webkit-scrollbar-thumb:active {
+    background-color: #218E21;
+}

--- a/ShapeDungeon/wwwroot/css/site.css
+++ b/ShapeDungeon/wwwroot/css/site.css
@@ -16,3 +16,7 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+.bttr-dropdown {
+    color: #ADAFAE!important;
+}

--- a/ShapeDungeon/wwwroot/js/enemy/range.js
+++ b/ShapeDungeon/wwwroot/js/enemy/range.js
@@ -1,4 +1,6 @@
-﻿const minLevelEl = document.getElementById("min-level");
+﻿import { getCookie } from "../shared/cookie-get.js";
+
+const minLevelEl = document.getElementById("min-level");
 const maxLevelEl = document.getElementById("max-level");
 
 minLevelEl.addEventListener("change", updateCookies);
@@ -19,24 +21,4 @@ maxLevelEl.value = getCookie("max");
 function updateCookies() {
     document.cookie = `min=${minLevelEl.value}`;
     document.cookie = `max=${maxLevelEl.value}`;
-}
-
-function getCookie(cookieName) {
-    let name = cookieName + "=";
-    let decodedCookie = decodeURIComponent(document.cookie);
-    let cookies = decodedCookie.split(';');
-
-    for (let i = 0; i < cookies.length; i++) {
-        let c = cookies[i];
-
-        while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-        }
-
-        if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-        }
-    }
-
-    return "";
 }

--- a/ShapeDungeon/wwwroot/js/player/level-bar.js
+++ b/ShapeDungeon/wwwroot/js/player/level-bar.js
@@ -1,0 +1,6 @@
+﻿const levelBarEl = document.getElementById("level-bar");
+
+function updateBar(currentXp, xpRequired) {
+    const barPercentage = (currentXp * 100) / xpRequired;
+    levelBarEl.style.width = `${barPercentage}%`;
+}

--- a/ShapeDungeon/wwwroot/js/player/level-up-skill.js
+++ b/ShapeDungeon/wwwroot/js/player/level-up-skill.js
@@ -1,0 +1,76 @@
+﻿import { getCookie } from "../shared/cookie-get.js";
+
+const fastSwitchEl = document.getElementById("fast-level-up-switch");
+const confirmationWindowEl = document.getElementById("stat-confirmation");
+const statNameEl = document.getElementById("stat-name");
+const strengthConfirmEl = document.getElementById("strength-yes-btn");
+const vigorConfirmEl = document.getElementById("vigor-yes-btn");
+const agilityConfirmEl = document.getElementById("agility-yes-btn");
+const noBtnEl = document.getElementById("no-btn");
+
+const yesBtnCollection = [strengthConfirmEl, vigorConfirmEl, agilityConfirmEl];
+
+fastSwitchEl.addEventListener("click", toggleSwitch);
+
+strengthPlusEl.addEventListener("click", showConfirmationWindow);
+vigorPlusEl.addEventListener("click", showConfirmationWindow);
+agilityPlusEl.addEventListener("click", showConfirmationWindow);
+
+noBtnEl.addEventListener("click", closeConfirmationWindow);
+
+const switchCookieExists = document.cookie.includes("f-switch");
+if (!switchCookieExists)
+    document.cookie = "f-switch=no";
+
+const switchCookieOnLoad = getCookie("f-switch");
+switch (switchCookieOnLoad) {
+    case "yes": fastSwitchEl.checked = true; break;
+    case "no": fastSwitchEl.checked = false; break;
+    default: console.log("bruh, cookie for fast switch is buggy");
+}
+
+function toggleSwitch() {
+    const switchCookieBeforeToggle = getCookie("f-switch");
+    switch (switchCookieBeforeToggle) {
+        case "yes": document.cookie = "f-switch=no"; break;
+        case "no": document.cookie = "f-switch=yes"; break;
+    }
+}
+
+function showConfirmationWindow() {
+    const fSwitchCookie = getCookie("f-switch");
+    let statName = this.id.replace("-plus", "");
+    statName = statName.charAt(0).toUpperCase() + statName.slice(1);
+    statNameEl.innerText = statName;
+
+    if (fSwitchCookie === "yes") {
+        fastStatUpgrade(statName);
+    } else if (fSwitchCookie === "no") {
+        confirmationWindowEl.classList.remove("hidden");
+        toggleStatConfirmYesButton(statName);
+    }
+}
+
+function fastStatUpgrade(statToUpgrade) {
+    switch (statToUpgrade) {
+        case "Strength": strengthConfirmEl.click(); break;
+        case "Vigor": vigorConfirmEl.click(); break;
+        case "Agility": agilityConfirmEl.click(); break;
+    }
+}
+
+function closeConfirmationWindow() {
+    confirmationWindowEl.classList.add("hidden");
+    toggleStatConfirmYesButton();
+}
+
+function toggleStatConfirmYesButton(btnToDisplay) {
+    for (const btn of yesBtnCollection)
+        btn.classList.add("hidden");
+
+    switch (btnToDisplay) {
+        case "Strength": strengthConfirmEl.classList.remove("hidden"); break;
+        case "Vigor": vigorConfirmEl.classList.remove("hidden"); break;
+        case "Agility": agilityConfirmEl.classList.remove("hidden"); break;
+    }
+}

--- a/ShapeDungeon/wwwroot/js/player/toggle-skillpoint-btns.js
+++ b/ShapeDungeon/wwwroot/js/player/toggle-skillpoint-btns.js
@@ -1,0 +1,21 @@
+﻿const strengthPlusEl = document.getElementById("strength-plus");
+const vigorPlusEl = document.getElementById("vigor-plus");
+const agilityPlusEl = document.getElementById("agility-plus");
+
+function toggleSkillpointBtns(skillpointCount) {
+    if (skillpointCount <= 0) {
+        strengthPlusEl.classList.remove("btn-outline-success");
+        vigorPlusEl.classList.remove("btn-outline-success");
+        agilityPlusEl.classList.remove("btn-outline-success");
+        strengthPlusEl.classList.add("disabled", "btn-outline-dark");
+        vigorPlusEl.classList.add("disabled", "btn-outline-dark");
+        agilityPlusEl.classList.add("disabled", "btn-outline-dark");
+    } else {
+        strengthPlusEl.classList.remove("disabled", "btn-outline-dark");
+        vigorPlusEl.classList.remove("disabled", "btn-outline-dark");
+        agilityPlusEl.classList.remove("disabled", "btn-outline-dark");
+        strengthPlusEl.classList.add("btn-outline-success");
+        vigorPlusEl.classList.add("btn-outline-success");
+        agilityPlusEl.classList.add("btn-outline-success");
+    }
+}

--- a/ShapeDungeon/wwwroot/js/shared/cookie-get.js
+++ b/ShapeDungeon/wwwroot/js/shared/cookie-get.js
@@ -1,0 +1,19 @@
+﻿export function getCookie(cookieName) {
+    let name = cookieName + "=";
+    let decodedCookie = decodeURIComponent(document.cookie);
+    let cookies = decodedCookie.split(';');
+
+    for (let i = 0; i < cookies.length; i++) {
+        let c = cookies[i];
+
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+
+    return "";
+}


### PR DESCRIPTION
# Features
### Current Player Screen
- Displays the currently active player's info.
- Allows the user to level up stats if there are available skillpoints.
- Fast level-up switch - removes the confirmation screen when leveling up a skill (_has a cookie so the selection is remembered on page reload_).

### Select Player Screen
- Displays all players in the DB.
- Allows the user to select a new player by clicking on their name.
- There may be a limit of total created players as I have two ideas:
        - reset the level so each player character has a fresh run (_doesn't require limit_).
        - keep the level so each player character can help the others (_requires limit_).