### PR TITLE
Bugfix - User Could Leave Combat Using Player Dropdown

### DIFF
--- a/ShapeDungeon/Controllers/PlayerController.cs
+++ b/ShapeDungeon/Controllers/PlayerController.cs
@@ -25,8 +25,11 @@ namespace ShapeDungeon.Controllers
         }
 
         [HttpGet]
-        public IActionResult Create()
+        public async Task<IActionResult> Create()
         {
+            var isAnyInCombat = await _playerGetService.GetIsAnyInCombat();
+            if (isAnyInCombat) return RedirectToAction("Index", "Home");
+
             var model = new PlayerDto();
             return View(model);
         }
@@ -54,6 +57,9 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Current()
         {
+            var isAnyInCombat = await _playerGetService.GetIsAnyInCombat();
+            if (isAnyInCombat) return RedirectToAction("Index", "Home");
+
             var activePlayer = await _playerGetService.GetActivePlayer();
             return View(activePlayer);
         }
@@ -61,6 +67,9 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Select()
         {
+            var isAnyInCombat = await _playerGetService.GetIsAnyInCombat();
+            if (isAnyInCombat) return RedirectToAction("Index", "Home");
+
             var playerList = await _playerGetService.GetAllPlayersAsync();
             return View(playerList);
         }
@@ -68,6 +77,9 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Switch(Guid newId)
         {
+            var isAnyInCombat = await _playerGetService.GetIsAnyInCombat();
+            if (isAnyInCombat) return RedirectToAction("Index", "Home");
+
             await _playerSelectService.UpdateActivePlayer(newId);
             return RedirectToAction("Select");
         }
@@ -75,6 +87,9 @@ namespace ShapeDungeon.Controllers
         [HttpGet]
         public async Task<IActionResult> Increase(CharacterStat statToIncrease)
         {
+            var isAnyInCombat = await _playerGetService.GetIsAnyInCombat();
+            if (isAnyInCombat) return RedirectToAction("Index", "Home");
+
             await _playerUpdateService.IncreaseStat(statToIncrease);
             return RedirectToAction("Current");
         }

--- a/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
+++ b/ShapeDungeon/Interfaces/Services/Players/IPlayerGetService.cs
@@ -10,5 +10,6 @@ namespace ShapeDungeon.Interfaces.Services.Players
         Task<PlayerDto> GetActivePlayer();
 
         Task<PlayerStatsResponse> GetActivePlayerStats();
+        Task<bool> GetIsAnyInCombat();
     }
 }

--- a/ShapeDungeon/Services/Players/PlayerGetService.cs
+++ b/ShapeDungeon/Services/Players/PlayerGetService.cs
@@ -44,5 +44,9 @@ namespace ShapeDungeon.Services.Players
         public async Task<PlayerStatsResponse> GetActivePlayerStats()
             => await _playerRepository.GetFirstAsync(
                 new PlayerIsActiveSpecification());
+
+        public async Task<bool> GetIsAnyInCombat()
+            => await _playerRepository.IsValidByAsync(
+                new PlayerIsInCombatSpecification());
     }
 }

--- a/ShapeDungeon/Specifications/Players/PlayerIsInCombatSpecification.cs
+++ b/ShapeDungeon/Specifications/Players/PlayerIsInCombatSpecification.cs
@@ -1,0 +1,18 @@
+﻿using ShapeDungeon.Entities;
+using System.Linq.Expressions;
+
+namespace ShapeDungeon.Specifications.Players
+{
+    public class PlayerIsInCombatSpecification : Specification<Player>
+    {
+        public PlayerIsInCombatSpecification()
+        {
+        }
+
+        public override bool IsSatisfiedBy(Player player)
+            => player.IsInCombat;
+
+        public override Expression<Func<Player, bool>> ToExpression()
+            => player => player.IsInCombat;
+    }
+}

--- a/ShapeDungeon/Views/Shared/_Layout.cshtml
+++ b/ShapeDungeon/Views/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light border-bottom box-shadow mb-3">
+        <nav id="main-navbar" class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light border-bottom box-shadow mb-3">
             <div class="container-fluid">
                 <a class="navbar-brand text-primary" asp-area="" asp-controller="Home" asp-action="Active">
                     <partial name="_Logo" />

--- a/ShapeDungeon/wwwroot/js/combat/combat-action.js
+++ b/ShapeDungeon/wwwroot/js/combat/combat-action.js
@@ -1,5 +1,6 @@
 ﻿import { updateEnemyHpBar, updatePlayerHpBar } from "../combat/combat-hp-bars.js";
 import { shake } from "../animations/shake.js";
+import { disableNavbar } from "../combat/combat-navbar.js";
 
 // Buttons.
 const attackBtn = document.getElementById("attack-btn");
@@ -138,4 +139,7 @@ function onCombatPageLoad() {
     // Update hp bars.
     updateEnemyHpBar(currentHpEnemyEl.innerText, totalHpEnemyEl.innerText);
     updatePlayerHpBar(currentHpPlayerEl.innerText, totalHpPlayerEl.innerText);
+
+    console.log("bruh")
+    disableNavbar();
 }

--- a/ShapeDungeon/wwwroot/js/combat/combat-navbar.js
+++ b/ShapeDungeon/wwwroot/js/combat/combat-navbar.js
@@ -1,0 +1,18 @@
+﻿const mainNavbarEl = document.getElementById("main-navbar");
+
+function createNavOverlay() {
+    const overlayEl = document.createElement("div");
+
+    overlayEl.style.position = "absolute";
+    overlayEl.style.width = "100%";
+    overlayEl.style.height = "100%";
+    overlayEl.style.background = "#000000";
+    overlayEl.style.opacity = "50%";
+
+    return overlayEl;
+}
+
+export function disableNavbar() {
+    const childEl = createNavOverlay();
+    mainNavbarEl.appendChild(childEl);
+}


### PR DESCRIPTION
### Bug Info
- When a player is in combat they should finish their combat before doing anything else.
- The player dropdown & controller actions were still accessible despite this requirement.

### Resolution
- Added a method to the player get service that gets true if there's any player with IsInCombat property == true.
- Used the new method to redirect to the combat page when player controller actions were called.
- Also added an overlay over the navbar so it's disabled, also giving the user a visual cue that they can't do anything else while in combat.